### PR TITLE
OPS-6920 updating labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # Kubernetes Cost Report
+
 <a href='https://github.com/jpoles1/gopherbadger' target='_blank'>![gopherbadger-tag-do-not-edit](https://img.shields.io/badge/Go%20Coverage-76%25-brightgreen.svg?longCache=true&style=flat)</a>
 [![Docker](https://github.com/empathyco/platform-cost-report/actions/workflows/docker.yml/badge.svg)](https://github.com/empathyco/platform-cost-report/actions/workflows/docker.yml)
 [![Gosec](https://github.com/empathyco/platform-cost-report/actions/workflows/gosec.yaml/badge.svg)](https://github.com/empathyco/platform-cost-report/actions/workflows/gosec.yaml)
 [![Reviewdog](https://github.com/empathyco/platform-cost-report/actions/workflows/reviewdog.yml/badge.svg)](https://github.com/empathyco/platform-cost-report/actions/workflows/reviewdog.yml)
+
 ## Deep Dive Explanation
+
 [Kubernetes Cost Report](https://medium.com/empathyco/cloud-finops-part-4-kubernetes-cost-report-b4964be02dc3)
+
 ## Architecture
+
 ![](docs/diagram.png)
+
 ## Requirements
 
 ```sh
@@ -40,6 +46,7 @@ To be able to query for prices you should have the following permissions:
     ]
 }
 ```
+
 You could run the terraform code to create it.
 
 set the following variables to be able to run the code:
@@ -62,6 +69,7 @@ make build
 ## Docker
 make docker
 ```
+
 For those who wants keep it simple and avoid install a lot of things:
 
 ```sh
@@ -87,7 +95,7 @@ go run main.go
 
 | Name                                   | Description       |
 |----------------------------------------|-------------------|
-| label_beta_kubernetes_io_instance_type | machine type      |
+| label_node_kubernetes_io_instance_type | machine type      |
 | label_eks_amazonaws_com_capacity_type  | instance type     |
 | vcpu                                   | virtual cpu       |
 | memory                                 | memory            |
@@ -100,7 +108,7 @@ go run main.go
 
 | Name                                   | Description       |
 |----------------------------------------|-------------------|
-| label_beta_kubernetes_io_instance_type | machine type      |
+| label_node_kubernetes_io_instance_type | machine type      |
 | label_eks_amazonaws_com_capacity_type  | instance type     |
 | vcpu                                   | virtual cpu       |
 | memory                                 | memory            |
@@ -108,20 +116,22 @@ go run main.go
 | Description                            | description       |
 | label_topology_kubernetes_io_zone      | availability zone |
 | region                                 | region            |
+
 ### instance_mem_price
 
 | Name                                   | Description       |
 |----------------------------------------|-------------------|
-| label_beta_kubernetes_io_instance_type | machine type      |
+| label_node_kubernetes_io_instance_type | machine type      |
 | label_eks_amazonaws_com_capacity_type  | instance type     |
 | unit                                   | unit              |
 | label_topology_kubernetes_io_zone      | availability zone |
 | region                                 | region            |
 
 ### instance_cpu_price
+
 | Name                                   | Description       |
 |----------------------------------------|-------------------|
-| label_beta_kubernetes_io_instance_type | machine type      |
+| label_node_kubernetes_io_instance_type | machine type      |
 | label_eks_amazonaws_com_capacity_type  | instance type     |
 | unit                                   | unit              |
 | label_topology_kubernetes_io_zone      | availability zone |
@@ -131,7 +141,7 @@ go run main.go
 
 | Name                                   | Description       |
 |----------------------------------------|-------------------|
-| label_beta_kubernetes_io_instance_type | machine type      |
+| label_node_kubernetes_io_instance_type | machine type      |
 | label_eks_amazonaws_com_capacity_type  | instance type     |
 | unit                                   | unit              |
 | label_topology_kubernetes_io_zone      | availability zone |
@@ -141,7 +151,7 @@ go run main.go
 
 | Name                                   | Description       |
 |----------------------------------------|-------------------|
-| label_beta_kubernetes_io_instance_type | machine type      |
+| label_node_kubernetes_io_instance_type | machine type      |
 | label_eks_amazonaws_com_capacity_type  | instance type     |
 | unit                                   | unit              |
 | label_topology_kubernetes_io_zone      | availability zone |

--- a/charts/kubernetes-cost-report/dashboards/kubernetes-cost-report.json
+++ b/charts/kubernetes-cost-report/dashboards/kubernetes-cost-report.json
@@ -1,4699 +1,5376 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "8.3.1"
-    },
-    {
-      "type": "panel",
-      "id": "graph",
-      "name": "Graph",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "grafana-piechart-panel",
-      "name": "Pie Chart",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "singlestat",
-      "name": "Singlestat",
-      "version": ""
-    }
-  ],
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": "-- Grafana --",
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "target": {
-            "limit": 100,
-            "matchAny": false,
-            "tags": [],
-            "type": "dashboard"
-          },
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
           "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 877,
+  "iteration": 1663758332421,
+  "links": [],
+  "liveNow": true,
+  "panels": [
+    {
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 1
+          },
+          "id": 26,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": true,
+              "expr": "sort_desc (\n  sum by (label_beta_kubernetes_io_instance_type) (kube_node_labels{label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\"})\n)",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sort_desc (\n  sum by (label_node_kubernetes_io_instance_type) (kube_node_labels{label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\"})\n)",
+              "hide": false,
+              "refId": "B"
+            }
+          ],
+          "title": "On Demand Instance Type",
+          "transformations": [
+            {
+              "id": "labelsToFields",
+              "options": {
+                "valueLabel": "label_beta_kubernetes_io_instance_type"
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 1
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": true,
+              "expr": "sort_desc (\n  sum by (label_beta_kubernetes_io_instance_type) (kube_node_labels{label_eks_amazonaws_com_capacity_type=\"SPOT\"})\n)",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sort_desc (\n  sum by (label_node_kubernetes_io_instance_type) (kube_node_labels{label_eks_amazonaws_com_capacity_type=\"SPOT\"})\n)",
+              "hide": false,
+              "refId": "B"
+            }
+          ],
+          "title": "Spot Instance Type",
+          "transformations": [
+            {
+              "id": "labelsToFields",
+              "options": {
+                "valueLabel": "label_beta_kubernetes_io_instance_type"
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 4,
+            "x": 0,
+            "y": 9
+          },
+          "id": 43,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {
+              "valueSize": 100
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sum(\n  sum_over_time(\n    (\n    capacity_instance:spot_instance_cost:cost \n    OR \n    capacity_instance:on_demand_instance_cost:cost\n    )\n  [1d:1h])\n)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "A"
+            }
+          ],
+          "title": "Total Daily Cluster Cost",
+          "transformations": [
+            {
+              "id": "seriesToColumns",
+              "options": {
+                "byField": "Time"
+              }
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 8,
+            "x": 4,
+            "y": 9
+          },
+          "id": 53,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {
+              "valueSize": 100
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sum (\n  sum_over_time(\n    (\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:spot_idle_cpu_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:on_demand_idle_cpu_cost\n      OR\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:spot_idle_mem_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:on_demand_idle_mem_cost\n    )\n  [1d:1h])\n)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "A"
+            }
+          ],
+          "title": "Idle Daily Cluster Cost",
+          "transformations": [
+            {
+              "id": "seriesToColumns",
+              "options": {
+                "byField": "Time"
+              }
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 4,
+            "x": 12,
+            "y": 9
+          },
+          "id": 61,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sum_over_time(\n  sum (\n  \n      # See description for label_replace\n      label_replace(\n        zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n        OR\n        capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n        zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n        OR\n        capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "A"
+            }
+          ],
+          "title": "Usage Daily Cluster Cost",
+          "transformations": [
+            {
+              "id": "seriesToColumns",
+              "options": {
+                "byField": "Time"
+              }
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 4,
+            "x": 16,
+            "y": 9
+          },
+          "id": 52,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sum (\n  sum_over_time(\n    (\n          zone_capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:spot_shared_cpu_cost\n          OR\n          capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:on_demand_shared_cpu_cost\n          OR\n          zone_capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:spot_shared_mem_cost\n          OR\n          capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:on_demand_shared_mem_cost\n    )\n  [1d:1h])\n)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "A"
+            }
+          ],
+          "title": "Shared Daily Cluster Cost",
+          "transformations": [
+            {
+              "id": "seriesToColumns",
+              "options": {
+                "byField": "Time"
+              }
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decgbytes"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Cost"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "currencyUSD"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Total Cost"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "currencyUSD"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 4,
+            "x": 20,
+            "y": 9
+          },
+          "id": 24,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sum (sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes/1024/1024/1024))",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "{{persistentvolumeclaim}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sum(sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes/1024/1024/1024) * $pvcost)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "",
+              "refId": "B"
+            }
+          ],
+          "title": "Total Monthly PV Cost ",
+          "transformations": [
+            {
+              "id": "seriesToColumns",
+              "options": {
+                "byField": "Time"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "Value #A": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Value #A": "Total Size ",
+                  "Value #B": "Total Cost"
+                }
+              }
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "orange",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 4,
+            "y": 13
+          },
+          "id": 62,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {
+              "valueSize": 100
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sum (\n  sum_over_time(\n    (\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:spot_idle_cpu_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:on_demand_idle_cpu_cost\n      OR\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:spot_idle_mem_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:on_demand_idle_mem_cost\n    )\n  [1d:1h])\n)\n-\nsum_over_time(\n  sum (\n  \n      # See description for label_replace\n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n              - \n              zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n          ) > 0)\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n              -\n              zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n          ) > 0)\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "A"
+            }
+          ],
+          "title": "Available Daily Cluster Cost",
+          "transformations": [
+            {
+              "id": "seriesToColumns",
+              "options": {
+                "byField": "Time"
+              }
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 4,
+            "x": 8,
+            "y": 13
+          },
+          "id": 60,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {
+              "valueSize": 100
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sum_over_time(\n  sum (\n  \n      # See description for label_replace\n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n              - \n              zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n          ) > 0)\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n              -\n              zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n          ) > 0)\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "A"
+            }
+          ],
+          "title": "Underutilization Daily Cluster Cost",
+          "transformations": [
+            {
+              "id": "seriesToColumns",
+              "options": {
+                "byField": "Time"
+              }
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 46,
+          "options": {
+            "displayMode": "gradient",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": false
+          },
+          "pluginVersion": "9.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": false,
+              "expr": "sort_desc(\n  sum_over_time(\n    (    \n    capacity_instance:spot_instance_cost:cost \n    OR \n    capacity_instance:on_demand_instance_cost:cost\n    )\n  [1d:1h])\n)",
+              "format": "time_series",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Daily Cluster Cost per Instance Type and Capacity Type",
+          "transformations": [],
+          "type": "bargauge"
+        },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyEUR"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "id": 44,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.2.3",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": true,
+              "expr": "sum_over_time(\n  (\n    capacity_instance:spot_instance_cost:cost OR capacity_instance:on_demand_instance_cost:cost\n  )\n[1d:1h])",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": true,
+              "expr": "sum(\n  sum_over_time(\n    (\n    capacity_instance:spot_instance_cost:cost OR capacity_instance:on_demand_instance_cost:cost\n    )\n  [1d:1h])\n)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "B"
+            }
+          ],
+          "title": "Daily Cluster Cost per Instance and Capacity Type",
+          "transformations": [],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 54,
+          "options": {
+            "displayMode": "gradient",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": false
+          },
+          "pluginVersion": "9.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": false,
+              "expr": "sort_desc(\n  sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (\n    sum_over_time(\n      (\n        zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:spot_idle_cpu_cost\n        OR\n        capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:on_demand_idle_cpu_cost\n        OR\n        zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:spot_idle_mem_cost\n        OR\n        capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:on_demand_idle_mem_cost\n      )\n    [1d:1h])\n)\n)",
+              "format": "time_series",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Daily Idle Cost per Instance Type and Capacity Type",
+          "transformations": [],
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyEUR"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 51,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.2.3",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": true,
+              "expr": "sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (\n  sum_over_time(\n    (\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:spot_idle_cpu_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:on_demand_idle_cpu_cost\n      OR\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:spot_idle_mem_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:on_demand_idle_mem_cost\n    )\n  [1d:1h])\n)",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": true,
+              "expr": "sum (\n  sum_over_time(\n    (\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:spot_idle_cpu_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:on_demand_idle_cpu_cost\n      OR\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:spot_idle_mem_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:on_demand_idle_mem_cost\n    )\n  [1d:1h])\n)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (\n  sum_over_time(\n    (\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:spot_idle_cpu_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:on_demand_idle_cpu_cost\n      OR\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:spot_idle_mem_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:on_demand_idle_mem_cost\n    )\n  [1d:1h])\n)",
+              "hide": false,
+              "refId": "C"
+            }
+          ],
+          "title": "Daily Idle Cost per Instance and Capacity Type",
+          "transformations": [],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 35
+          },
+          "id": 59,
+          "options": {
+            "displayMode": "gradient",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": false
+          },
+          "pluginVersion": "9.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": false,
+              "expr": "sort_desc (\n  sum_over_time(\n      sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (\n      \n\t      # See description for label_replace\n\t      label_replace(\n\t          ((\n\t              zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n\t              - \n\t              zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n\t          ) > 0)\n\t          OR\n\t          ((\n\t              capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n\t              -\n\t              capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n\t          ) > 0)\n\t      , \"resource\", \"CPU\", \"\",\"\")\n\t      \n\t      OR \n\t      \n\t      label_replace(\n\t          ((\n\t              zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n\t              -\n\t              zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n\t          ) > 0)\n\t          OR\n\t          ((\n\t              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n\t              -\n\t              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n\t          ) > 0)\n\t      , \"resource\", \"memory\", \"\",\"\")\n\n    )\n  [1d:1h])\n)",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Daily Underutilization Cost per Instance Type and Capacity Type",
+          "transformations": [],
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "label_replace is used to ALWAYS have a different label (resource) when doing OR, so that no time series is filtered by binary operations (capacity_type for internal OR, resource for external OR)\n\nIf for example a pod has CPU requests but not memory requests, the binary sum (+) will filter the CPU sum (will not count for them)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 47,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum_over_time(\n  sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (\n  \n      # See description for label_replace\n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n              - \n              zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n          ) > 0)\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n              -\n              zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n          ) > 0)\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum_over_time(\n  sum (\n  \n      # See description for label_replace\n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n              - \n              zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n          ) > 0)\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n              -\n              zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n          ) > 0)\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "B"
+            }
+          ],
+          "title": "Daily Underutilization Cost per Instance Type and Capacity Type",
+          "transformations": [],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 44
+          },
+          "id": 55,
+          "options": {
+            "displayMode": "gradient",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": false
+          },
+          "pluginVersion": "9.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": false,
+              "expr": "sort_desc(\n  sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (\n    sum_over_time(\n      (\n            zone_capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:spot_shared_cpu_cost\n            OR\n            capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:on_demand_shared_cpu_cost\n            OR\n            zone_capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:spot_shared_mem_cost\n            OR\n            capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:on_demand_shared_mem_cost\n      )\n    [1d:1h])\n  )\n)",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Daily Shared Cost per Instance Type and Capacity Type",
+          "transformations": [],
+          "type": "bargauge"
+        },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyEUR"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 44
+          },
+          "id": 50,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "sortBy": "Last *",
+              "sortDesc": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "8.2.3",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": true,
+              "expr": "sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (\n  sum_over_time(\n    (\n          zone_capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:spot_shared_cpu_cost\n          OR\n          capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:on_demand_shared_cpu_cost\n          OR\n          zone_capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:spot_shared_mem_cost\n          OR\n          capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:on_demand_shared_mem_cost\n    )\n  [1d:1h])\n)",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": true,
+              "expr": "sum (\n  sum_over_time(\n    (\n          zone_capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:spot_shared_cpu_cost\n          OR\n          capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:on_demand_shared_cpu_cost\n          OR\n          zone_capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:spot_shared_mem_cost\n          OR\n          capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:on_demand_shared_mem_cost\n    )\n  [1d:1h])\n)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "B"
+            }
+          ],
+          "title": "Daily Shared Cost per Instance and Capacity Type",
+          "transformations": [],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "label_replace is used to ALWAYS have a different label (resource) when doing OR, so that no time series is filtered by binary operations (capacity_type for internal OR, resource for external OR)\n\nIf for example a pod has CPU requests but not memory requests, the binary sum (+) will filter the CPU sum (will not count for them)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 53
+          },
+          "id": 74,
+          "options": {
+            "displayMode": "gradient",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": false
+          },
+          "pluginVersion": "9.0.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": false,
+              "expr": "sort_desc (\nsum_over_time(\n  sum by (namespace) (\n  \n      # See description for label_replace\n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n              - \n              zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n          ) > 0)\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n              -\n              zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n          ) > 0)\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])\n)",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Daily Total Cost per Namespace",
+          "transformations": [
+            {
+              "id": "seriesToColumns",
+              "options": {
+                "byField": "Time"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Value #A": "CPU Cost Per Day"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "CPU Cost Per Day"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "bargauge"
         }
-      ]
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster (Global)",
+      "type": "row"
     },
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "iteration": 1649927656798,
-    "links": [],
-    "liveNow": true,
-    "panels": [
-      {
-        "collapsed": false,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 0
-        },
-        "id": 19,
-        "panels": [],
-        "title": "Cluster (Global)",
-        "type": "row"
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
       },
-      {
-        "datasource": "${DS_PROMETHEUS}",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 57,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Namespace",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "label_replace is used to ALWAYS have a different label (resource) when doing OR, so that no time series is filtered by binary operations (capacity_type for internal OR, resource for external OR)\n\nIf for example a pod has CPU requests but not memory requests, the binary sum (+) will filter the CPU sum (will not count for them)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 79,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": false
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": false,
+          "expr": "sort_desc (\nsum_over_time(\n  sum by (namespace) (\n  \n      # See description for label_replace\n      label_replace(\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n                > \n                zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n            )\n            OR\n            zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          )\n          OR\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n                >\n                capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n            )\n            OR\n            zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          )\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n                >\n                zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n            )\n            OR\n            zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n          )\n          OR\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n                >\n                capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n            ) \n            OR capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n          )\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])\n)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{namespace}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Daily Total Cost per Namespace",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "Time"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
             },
-            "custom": {
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "CPU Cost Per Day"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "CPU Cost Per Day"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "label_replace is used to ALWAYS have a different label (resource) when doing OR, so that no time series is filtered by binary operations (capacity_type for internal OR, resource for external OR)\n\nIf for example a pod has CPU requests but not memory requests, the binary sum (+) will filter the CPU sum (will not count for them)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
               },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 63,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": false
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": false,
+          "expr": "sort_desc (\nsum_over_time(\n  sum by (namespace) (\n  \n      # See description for label_replace\n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n              - \n              zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n          ) > 0)\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n              -\n              zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n          ) > 0)\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])\n)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{namespace}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Daily Underutilization Cost per Namespace",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "Time"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "CPU Cost Per Day"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "CPU Cost Per Day"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "label_replace is used to ALWAYS have a different label (resource) when doing OR, so that no time series is filtered by binary operations (capacity_type for internal OR, resource for external OR)\n\nIf for example a pod has CPU requests but not memory requests, the binary sum (+) will filter the CPU sum (will not count for them)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
               },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 58,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": false
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": false,
+          "expr": "sort_desc (\nsum_over_time(\n    sum by (namespace) (\n        # See description for label_replace\n        label_replace(\n\t\t    zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n            OR\n            capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n        , \"resource\", \"CPU\", \"\",\"\")\n        \n        OR \n        \n        label_replace(\n\t\t    zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n            OR\n            capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n        , \"resource\", \"memory\", \"\",\"\")\n\n\t)\n[1d:1h])\n)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{namespace}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Daily Requests Cost per Namespace",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "Time"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "CPU Cost Per Day"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "CPU Cost Per Day"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
               },
-              "thresholdsStyle": {
-                "mode": "off"
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 34,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "vertical",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": false
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": false,
+          "expr": "sort_desc(\nsum_over_time(\n    sum by (namespace) (\n        # See description for label_replace\n        label_replace(\n\t\t    zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n            OR\n            capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n        , \"resource\", \"CPU\", \"\",\"\")\n        \n        OR \n        \n        label_replace(\n\t\t    zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n            OR\n            capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n        , \"resource\", \"memory\", \"\",\"\")\n\n\t)\n[1d:1h])\n)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{namespace}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Daily Usage Cost per Namespace ",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "Time"
+          }
+        }
+      ],
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 37
+      },
+      "id": 65,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": false,
+          "expr": "sort_desc(\n  sum_over_time(\n    sum by (namespace) (\n      label_replace(((\n          (sum by (namespace) (zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost))\n          -\n          (sum by (namespace) (zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost))\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (sum by (namespace) (capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost))\n          -\n          (sum by (namespace) (capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost))\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Daily CPU Underutilization Cost Per Namespace",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "Daily CPU Underutilization Cost",
+              "namespace": "Namespace"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 37
+      },
+      "id": 30,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": false,
+          "expr": "sort_desc(\n\tsum_over_time(\n\t\tsum by (namespace) (\n\n\t\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n\t\t\tOR\n\t\t\tcapacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n\n\t\t)\n\t[1d:1h])\n)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Daily CPU Requests Cost Per Namespace",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "Daily CPU Requests Cost ",
+              "namespace": "Namespace"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 37
+      },
+      "id": 31,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": false,
+          "expr": "sort_desc(\n\tsum_over_time(\n\t\tsum by (namespace) (\n\n\t\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n\t\t\tOR\n\t\t\tcapacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n\n\t\t)\n\t[1d:1h])\n)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Daily CPU Usage Cost Per Namespace ",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "Daily CPU Usage Cost",
+              "namespace": "Namespace"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 45
+      },
+      "id": 64,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": false,
+          "expr": "sort_desc(\n  sum_over_time(\n    sum by (namespace) (\n      label_replace(((\n          (sum by (namespace) (zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost))\n          -\n          (sum by (namespace) (zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost))\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (sum by (namespace) (capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost))\n          -\n          (sum by (namespace) (capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost))\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Daily Memory Underutilization Cost Per Namespace",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "Daily Memory Underutilization Cost",
+              "namespace": "Namespace"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 45
+      },
+      "id": 35,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": false,
+          "expr": "sort_desc(\n\tsum_over_time(\n\t\tsum by (namespace) (\n\n\t\t\tzone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n\t\t\tOR\n\t\t\tcapacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n\n\t\t)\n\t[1d:1h])\n)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Daily Memory Requests Cost per Namespace",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "Daily Memory Requests Cost",
+              "namespace": "Namespace"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 45
+      },
+      "id": 36,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": false,
+          "expr": "sort_desc(\n\tsum_over_time(\n\t\tsum by (namespace) (\n\n\t\t\tzone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n\t\t\tOR\n\t\t\tcapacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n\n\t\t)\n\t[1d:1h])\n)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Daily Memory Usage Cost Per Namespace",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "Time"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "Daily Memory Usage Cost",
+              "namespace": "Namespace"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "fillOpacity": 80,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 53
+      },
+      "id": 38,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "orientation": "auto",
+        "showValue": "always",
+        "stacking": "normal",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "8.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": false,
+          "expr": "sum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes/1024/1024/1024) * $pvcost)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Monthly PVs Total Cost",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "Time"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "PVCs Costs Per Day"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "PVCs Costs Per Day"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 61
+      },
+      "id": 49,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "sortBy": "Last",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes/1024/1024/1024) * $pvcost)",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{namespace}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Monthly PVs Total Cost",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "fillOpacity": 80,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 69
+      },
+      "id": 75,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "orientation": "auto",
+        "showValue": "always",
+        "stacking": "normal",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "8.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": false,
+          "expr": "(sum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes/1024/1024/1024))\n-\nsum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes/1024/1024/1024))\n) * $pvcost",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Monthly PVs Underutilization Cost",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "Time"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "PVCs Costs Per Day"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "PVCs Costs Per Day"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 69
+      },
+      "id": 76,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": true,
+          "expr": "(sum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes/1024/1024/1024))\n-\nsum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes/1024/1024/1024))\n) * $pvcost",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{namespace}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Monthly PVs Underutilization Cost",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "fillOpacity": 80,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 77
+      },
+      "id": 77,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "orientation": "auto",
+        "showValue": "always",
+        "stacking": "normal",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "8.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": false,
+          "expr": "sum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes/1024/1024/1024)) * $pvcost",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Monthly PVs Usage Cost",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "Time"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "PVCs Costs Per Day"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": true,
+                "field": "PVCs Costs Per Day"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "currencyUSD"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 77
+      },
+      "id": 78,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.3.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes/1024/1024/1024)) * $pvcost",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "{{namespace}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Monthly PVs Usage Cost",
+      "transformations": [],
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 85
+      },
+      "id": 10,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "label_replace is used to ALWAYS have a different label (resource) when doing OR, so that no time series is filtered by binary operations (capacity_type for internal OR, resource for external OR)\n\nIf for example a pod has CPU requests but not memory requests, the binary sum (+) will filter the CPU sum (will not count for them)",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 2,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 3
+          },
+          "id": 81,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "vertical",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": false,
+            "text": {}
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": false,
+              "expr": "sort_desc (\nsum_over_time(\n  sum by (pod) (\n  \n      # See description for label_replace\n      label_replace(\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n                > \n                zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n            )\n            OR\n            zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n          )\n          OR\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n                >\n                capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n            )\n            OR\n            zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n          )\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n                >\n                zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n            )\n            OR\n            zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n          )\n          OR\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n                >\n                capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n            ) \n            OR capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n          )\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])\n)",
+              "format": "time_series",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Daily Total Cost per Pod",
+          "transformations": [],
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 12
+          },
+          "id": 71,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": false,
+              "expr": "sort_desc(\n  sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n      label_replace(((\n          (zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost{namespace=\"$namespace\"})\n          -\n          (zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\"})\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost{namespace=\"$namespace\"})\n          -\n          (capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost{namespace=\"$namespace\"})\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Daily CPU Underutilization Costs Per Pod",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "label_beta_kubernetes_io_instance_type": true,
+                  "label_eks_amazonaws_com_capacity_type": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Value": "Daily CPU Underutilization Cost ",
+                  "Value #A": "Daily CPU Underutilization Cost",
+                  "pod": "Pod"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 12
+          },
+          "id": 68,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sort_desc(\n    sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost{namespace=\"$namespace\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost{namespace=\"$namespace\"}\n\n\t)\n[1d:1h])\n)",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Daily CPU Requests Costs Per Pod",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "label_beta_kubernetes_io_instance_type": true,
+                  "label_eks_amazonaws_com_capacity_type": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Value": "Daily CPU Requests Costs",
+                  "Value #A": "Daily CPU Requests Costs",
+                  "pod": "Pod"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 12
+          },
+          "id": 66,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sort_desc(\n    sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost{namespace=\"$namespace\"}\n\n\t)\n[1d:1h])\n)",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Daily CPU Usage Costs Per Pod",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "label_beta_kubernetes_io_instance_type": true,
+                  "label_eks_amazonaws_com_capacity_type": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Value": "Daily CPU Usage Costs",
+                  "Value #A": "Daily CPU Usage Costs",
+                  "pod": "Pod"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 0,
+            "y": 20
+          },
+          "id": 70,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": []
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": false,
+              "expr": "sort_desc(\n  sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n      label_replace(((\n          (zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost{namespace=\"$namespace\"})\n          -\n          (zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\"})\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost{namespace=\"$namespace\"})\n          -\n          (capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\"})\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Daily Memory Underutilization Costs Per Pod",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "label_beta_kubernetes_io_instance_type": true,
+                  "label_eks_amazonaws_com_capacity_type": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Value": "Daily Memory Underutilization Cost per Pod",
+                  "Value #A": "Daily Memory Underutilization Cost",
+                  "pod": "Pod"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 8,
+            "y": 20
+          },
+          "id": 69,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sort_desc(\nsum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost{namespace=\"$namespace\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost{namespace=\"$namespace\"}\n\n\t)\n[1d:1h])\n)",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}} ",
+              "refId": "A"
+            }
+          ],
+          "title": "Daily Memory Requests Costs Per Pod",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "label_beta_kubernetes_io_instance_type": true,
+                  "label_eks_amazonaws_com_capacity_type": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Value": "Daily Memory Requests Cost",
+                  "Value #A": "Daily Memory Requests Costs",
+                  "pod": "Pod"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 20
+          },
+          "id": 67,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sort_desc(\nsum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\"}\n\n\t)\n[1d:1h])\n)",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}} ",
+              "refId": "A"
+            }
+          ],
+          "title": "Daily Memory Usage Costs Per Pod",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "label_beta_kubernetes_io_instance_type": true,
+                  "label_eks_amazonaws_com_capacity_type": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Value": "Daily Memory Usage Cost",
+                  "Value #A": "Daily Memory Usage Costs",
+                  "pod": "Pod"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
               }
             },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
+            "overrides": []
           },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 1
-        },
-        "id": 26,
-        "options": {
-          "legend": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "displayMode": "table",
-            "placement": "right"
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 27
           },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": true,
-            "expr": "sort_desc (\n  sum by (label_beta_kubernetes_io_instance_type) (kube_node_labels{label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\"})\n)",
-            "instant": false,
-            "interval": "",
-            "legendFormat": "",
-            "refId": "A"
-          }
-        ],
-        "title": "On Demand Instance Type",
-        "transformations": [
-          {
-            "id": "labelsToFields",
-            "options": {
-              "valueLabel": "label_beta_kubernetes_io_instance_type"
-            }
-          }
-        ],
-        "type": "timeseries"
-      },
-      {
-        "datasource": "${DS_PROMETHEUS}",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
+          "id": 11,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
             },
-            "custom": {
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
               },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
+              "exemplar": true,
+              "expr": "sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, pod) (\n    sum by (pod, node) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~\"$namespace\", pod=~\"$pod\"})\n    * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) \n    sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job=\"kube-state-metrics\"})\n)",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "CPU Usage - {{pod}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
               },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
+              "exemplar": true,
+              "expr": "sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, pod) (\n    cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=~\"$namespace\", pod=~\"$pod\"}\n    * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) \n    sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job=\"kube-state-metrics\"})\n)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "CPU Requests - {{pod}}",
+              "refId": "B"
+            }
+          ],
+          "title": "CPU Requests vs Usage Per Pod",
+          "transformations": [],
+          "type": "timeseries"
+        },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
               },
-              "thresholdsStyle": {
-                "mode": "off"
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 27
+          },
+          "id": 12,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": true,
+              "expr": "sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, pod) (\n  sum by (pod, node) (container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$pod\", name!=\"\"})\n  * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) \n  sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job=\"kube-state-metrics\"})\n)",
+              "instant": false,
+              "interval": "",
+              "legendFormat": "Memory Usage - {{pod}} ",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": true,
+              "expr": "sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, pod) (\n    cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=~\"$namespace\", pod=~\"$pod\"}\n    * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) \n    sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job=\"kube-state-metrics\"})\n)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Memory Requests - {{pod}} ",
+              "refId": "B"
+            }
+          ],
+          "title": "Memory Requests vs Usage Per Pod",
+          "transformations": [],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 35
+          },
+          "id": 72,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sort_desc(\n  sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n      label_replace(((\n          (zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sort_desc(\n  sum_over_time(\n\tsum (\n      label_replace(((\n          (zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "B"
+            }
+          ],
+          "title": "Daily CPU Underutilization Costs Per Pod",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 35
+          },
+          "id": 73,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sort_desc(\n  sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n      label_replace(((\n          (zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sort_desc(\n  sum_over_time(\n\tsum (\n      label_replace(((\n          (zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "B"
+            }
+          ],
+          "title": "Daily Memory Underutilization Costs Per Pod",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 43
+          },
+          "id": 39,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum_over_time(\n\tsum (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "B"
+            }
+          ],
+          "title": "Daily CPU Requests Cost Per Pod",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 43
+          },
+          "id": 40,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum_over_time(\n\tsum (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "B"
+            }
+          ],
+          "title": "Daily Memory Requests Cost Per Pod",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 51
+          },
+          "id": 41,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum_over_time(\n\tsum (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "B"
+            }
+          ],
+          "title": "Daily CPU Usage Cost Per Pod",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "currencyUSD"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 51
+          },
+          "id": 42,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
+              "interval": "",
+              "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "exemplar": true,
+              "expr": "sum_over_time(\n\tsum (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Total",
+              "refId": "B"
+            }
+          ],
+          "title": "Daily Memory Usage Cost Per Pod",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decgbytes"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": ".*Cost"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "currencyUSD"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "PVC (Persistent Volume Claim)"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 554
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 59
+          },
+          "id": 8,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "frameIndex": 0,
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Underutilization Cost"
+              }
+            ]
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
+              "format": "table",
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{persistentvolumeclaim}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)\n-\nsum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024) * $pvcost",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\"}/1024/1024/1024) * $pvcost",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "E"
+            },
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": false,
+              "expr": "(sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)\n-\nsum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\"}/1024/1024/1024))\n* $pvcost",
+              "format": "table",
+              "hide": false,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "",
+              "refId": "F"
+            }
+          ],
+          "title": "Monthly PV Cost Per Pod",
+          "transformations": [
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "Value #A"
+                  }
+                ]
               }
             },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 1
-        },
-        "id": 2,
-        "options": {
-          "legend": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "displayMode": "table",
-            "placement": "right"
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": true,
-            "expr": "sort_desc (\n  sum by (label_beta_kubernetes_io_instance_type) (kube_node_labels{label_eks_amazonaws_com_capacity_type=\"SPOT\"})\n)",
-            "instant": false,
-            "interval": "",
-            "legendFormat": "",
-            "refId": "A"
-          }
-        ],
-        "title": "Spot Instance Type",
-        "transformations": [
-          {
-            "id": "labelsToFields",
-            "options": {
-              "valueLabel": "label_beta_kubernetes_io_instance_type"
-            }
-          }
-        ],
-        "type": "timeseries"
-      },
-      {
-        "datasource": "${DS_PROMETHEUS}",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "decimals": 2,
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "currencyUSD"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 4,
-          "x": 0,
-          "y": 9
-        },
-        "id": 43,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "text": {
-            "valueSize": 100
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "8.4.2",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": false,
-            "expr": "sum(\n  sum_over_time(\n    (\n    capacity_instance:spot_instance_cost:cost \n    OR \n    capacity_instance:on_demand_instance_cost:cost\n    )\n  [1d:1h])\n)",
-            "format": "table",
-            "hide": false,
-            "instant": true,
-            "interval": "",
-            "legendFormat": "Total",
-            "refId": "A"
-          }
-        ],
-        "title": "Total Daily Cluster Cost",
-        "transformations": [
-          {
-            "id": "seriesToColumns",
-            "options": {
-              "byField": "Time"
-            }
-          }
-        ],
-        "type": "stat"
-      },
-      {
-        "datasource": "${DS_PROMETHEUS}",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "orange",
-                  "value": 0
-                }
-              ]
-            },
-            "unit": "currencyUSD"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 8,
-          "x": 4,
-          "y": 9
-        },
-        "id": 53,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "text": {
-            "valueSize": 100
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "8.4.2",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": false,
-            "expr": "sum (\n  sum_over_time(\n    (\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:spot_idle_cpu_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:on_demand_idle_cpu_cost\n      OR\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:spot_idle_mem_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:on_demand_idle_mem_cost\n    )\n  [1d:1h])\n)",
-            "format": "table",
-            "hide": false,
-            "instant": true,
-            "interval": "",
-            "legendFormat": "Total",
-            "refId": "A"
-          }
-        ],
-        "title": "Idle Daily Cluster Cost",
-        "transformations": [
-          {
-            "id": "seriesToColumns",
-            "options": {
-              "byField": "Time"
-            }
-          }
-        ],
-        "type": "stat"
-      },
-      {
-        "datasource": "${DS_PROMETHEUS}",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "currencyUSD"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 4,
-          "x": 12,
-          "y": 9
-        },
-        "id": 61,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "8.4.2",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": false,
-            "expr": "sum_over_time(\n  sum (\n  \n      # See description for label_replace\n      label_replace(\n        zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n        OR\n        capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n        zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n        OR\n        capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])",
-            "format": "table",
-            "hide": false,
-            "instant": true,
-            "interval": "",
-            "legendFormat": "Total",
-            "refId": "A"
-          }
-        ],
-        "title": "Usage Daily Cluster Cost",
-        "transformations": [
-          {
-            "id": "seriesToColumns",
-            "options": {
-              "byField": "Time"
-            }
-          }
-        ],
-        "type": "stat"
-      },
-      {
-        "datasource": "${DS_PROMETHEUS}",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "decimals": 2,
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "currencyUSD"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 4,
-          "x": 16,
-          "y": 9
-        },
-        "id": 52,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "8.4.2",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": false,
-            "expr": "sum (\n  sum_over_time(\n    (\n          zone_capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:spot_shared_cpu_cost\n          OR\n          capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:on_demand_shared_cpu_cost\n          OR\n          zone_capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:spot_shared_mem_cost\n          OR\n          capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:on_demand_shared_mem_cost\n    )\n  [1d:1h])\n)",
-            "format": "table",
-            "hide": false,
-            "instant": true,
-            "interval": "",
-            "legendFormat": "Total",
-            "refId": "A"
-          }
-        ],
-        "title": "Shared Daily Cluster Cost",
-        "transformations": [
-          {
-            "id": "seriesToColumns",
-            "options": {
-              "byField": "Time"
-            }
-          }
-        ],
-        "type": "stat"
-      },
-      {
-        "datasource": "${DS_PROMETHEUS}",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "decgbytes"
-          },
-          "overrides": [
             {
-              "matcher": {
-                "id": "byName",
-                "options": "Cost"
-              },
-              "properties": [
-                {
-                  "id": "unit",
-                  "value": "currencyUSD"
-                }
-              ]
+              "id": "seriesToColumns",
+              "options": {
+                "byField": "persistentvolumeclaim"
+              }
             },
             {
-              "matcher": {
-                "id": "byName",
-                "options": "Total Cost"
-              },
-              "properties": [
-                {
-                  "id": "unit",
-                  "value": "currencyUSD"
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "persistentvolumeclaim 2": true
+                },
+                "indexByName": {
+                  "Time": 1,
+                  "Value #A": 2,
+                  "Value #B": 3,
+                  "Value #C": 4,
+                  "Value #D": 6,
+                  "Value #E": 5,
+                  "persistentvolumeclaim": 0
+                },
+                "renameByName": {
+                  "Value": "Cost",
+                  "Value #A": "Size",
+                  "Value #B": "Total Cost",
+                  "Value #C": "Used",
+                  "Value #D": "Free",
+                  "Value #E": "Usage Cost",
+                  "Value #F": "Underutilization Cost",
+                  "persistentvolumeclaim": "PVC (Persistent Volume Claim)"
                 }
-              ]
+              }
             }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": "prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decgbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 67
+          },
+          "id": 82,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": true,
+              "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\", persistentvolumeclaim=~\"$pvc\"}/1024/1024/1024)",
+              "format": "time_series",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{persistentvolumeclaim}} - Capacity",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "0": "p",
+                "1": "r",
+                "2": "o",
+                "3": "m",
+                "4": "e",
+                "5": "t",
+                "6": "h",
+                "7": "e",
+                "8": "u",
+                "9": "s"
+              },
+              "exemplar": true,
+              "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\", persistentvolumeclaim=~\"$pvc\"}/1024/1024/1024)",
+              "format": "time_series",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "legendFormat": "{{persistentvolumeclaim}} - Usage",
+              "refId": "C"
+            }
+          ],
+          "title": "PV Capacity vs Usage",
+          "transformations": [],
+          "type": "timeseries"
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Pod Per Namespace",
+      "type": "row"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "hide": 2,
+        "name": "region",
+        "query": "eu-west-1",
+        "skipUrlSync": false,
+        "type": "constant"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "velero",
+          "value": "velero"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(kube_pod_info, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_pod_info, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
           ]
         },
-        "gridPos": {
-          "h": 8,
-          "w": 4,
-          "x": 20,
-          "y": 9
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
         },
-        "id": 24,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "textMode": "auto"
+        "definition": "label_values(kube_pod_info{namespace=\"$namespace\"}, pod)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": true,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_pod_info{namespace=\"$namespace\"}, pod)",
+          "refId": "StandardVariableQuery"
         },
-        "pluginVersion": "8.4.2",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": false,
-            "expr": "sum (sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes/1024/1024/1024))",
-            "format": "table",
-            "instant": true,
-            "interval": "",
-            "intervalFactor": 2,
-            "legendFormat": "{{persistentvolumeclaim}}",
-            "refId": "A"
-          },
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": false,
-            "expr": "sum(sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes/1024/1024/1024) * $pvcost)",
-            "format": "table",
-            "hide": false,
-            "instant": true,
-            "interval": "",
-            "intervalFactor": 2,
-            "legendFormat": "",
-            "refId": "B"
-          }
-        ],
-        "title": "Total Monthly PV Cost ",
-        "transformations": [
-          {
-            "id": "seriesToColumns",
-            "options": {
-              "byField": "Time"
-            }
-          },
-          {
-            "id": "organize",
-            "options": {
-              "excludeByName": {
-                "Time": true,
-                "Value #A": true
-              },
-              "indexByName": {},
-              "renameByName": {
-                "Value #A": "Total Size ",
-                "Value #B": "Total Cost"
-              }
-            }
-          }
-        ],
-        "type": "stat"
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       },
       {
-        "datasource": "${DS_PROMETHEUS}",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "orange",
-                  "value": 0
-                }
-              ]
-            },
-            "unit": "currencyUSD"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 4,
-          "w": 4,
-          "x": 4,
-          "y": 13
-        },
-        "id": 62,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "text": {
-            "valueSize": 100
-          },
-          "textMode": "auto"
-        },
-        "pluginVersion": "8.4.2",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": false,
-            "expr": "sum (\n  sum_over_time(\n    (\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:spot_idle_cpu_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:on_demand_idle_cpu_cost\n      OR\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:spot_idle_mem_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:on_demand_idle_mem_cost\n    )\n  [1d:1h])\n)\n-\nsum_over_time(\n  sum (\n  \n      # See description for label_replace\n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n              - \n              zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n          ) > 0)\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n              -\n              zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n          ) > 0)\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])",
-            "format": "table",
-            "hide": false,
-            "instant": true,
-            "interval": "",
-            "legendFormat": "Total",
-            "refId": "A"
-          }
-        ],
-        "title": "Available Daily Cluster Cost",
-        "transformations": [
-          {
-            "id": "seriesToColumns",
-            "options": {
-              "byField": "Time"
-            }
-          }
-        ],
-        "type": "stat"
+        "description": "Price of GiB per month",
+        "hide": 2,
+        "label": "PV Cost GB/month",
+        "name": "pvcost",
+        "query": "0.089",
+        "skipUrlSync": false,
+        "type": "constant"
       },
       {
-        "datasource": "${DS_PROMETHEUS}",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 0
-                }
-              ]
-            },
-            "unit": "currencyUSD"
-          },
-          "overrides": []
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
         },
-        "gridPos": {
-          "h": 4,
-          "w": 4,
-          "x": 8,
-          "y": 13
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
         },
-        "id": 60,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "text": {
-            "valueSize": 100
-          },
-          "textMode": "auto"
+        "definition": "label_values(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"}, persistentvolumeclaim)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Persistent Volume Claim",
+        "multi": true,
+        "name": "pvc",
+        "options": [],
+        "query": {
+          "query": "label_values(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"}, persistentvolumeclaim)",
+          "refId": "StandardVariableQuery"
         },
-        "pluginVersion": "8.4.2",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": false,
-            "expr": "sum_over_time(\n  sum (\n  \n      # See description for label_replace\n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n              - \n              zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n          ) > 0)\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n              -\n              zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n          ) > 0)\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])",
-            "format": "table",
-            "hide": false,
-            "instant": true,
-            "interval": "",
-            "legendFormat": "Total",
-            "refId": "A"
-          }
-        ],
-        "title": "Underutilization Daily Cluster Cost",
-        "transformations": [
-          {
-            "id": "seriesToColumns",
-            "options": {
-              "byField": "Time"
-            }
-          }
-        ],
-        "type": "stat"
-      },
-      {
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "currencyUSD"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 0,
-          "y": 17
-        },
-        "id": 46,
-        "options": {
-          "displayMode": "gradient",
-          "orientation": "vertical",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showUnfilled": false
-        },
-        "pluginVersion": "8.4.2",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": false,
-            "expr": "sort_desc(\n  sum_over_time(\n    (    \n    capacity_instance:spot_instance_cost:cost \n    OR \n    capacity_instance:on_demand_instance_cost:cost\n    )\n  [1d:1h])\n)",
-            "format": "time_series",
-            "instant": true,
-            "interval": "",
-            "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
-            "refId": "A"
-          }
-        ],
-        "title": "Daily Cluster Cost per Instance Type and Capacity Type",
-        "transformations": [],
-        "type": "bargauge"
-      },
-      {
-        "datasource": "${DS_PROMETHEUS}",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "currencyEUR"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 12,
-          "y": 17
-        },
-        "id": 44,
-        "options": {
-          "legend": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "displayMode": "table",
-            "placement": "right",
-            "sortBy": "Last *",
-            "sortDesc": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "8.2.3",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": true,
-            "expr": "sum_over_time(\n  (\n    capacity_instance:spot_instance_cost:cost OR capacity_instance:on_demand_instance_cost:cost\n  )\n[1d:1h])",
-            "hide": false,
-            "instant": false,
-            "interval": "",
-            "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
-            "refId": "A"
-          },
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": true,
-            "expr": "sum(\n  sum_over_time(\n    (\n    capacity_instance:spot_instance_cost:cost OR capacity_instance:on_demand_instance_cost:cost\n    )\n  [1d:1h])\n)",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Total",
-            "refId": "B"
-          }
-        ],
-        "title": "Daily Cluster Cost per Instance and Capacity Type",
-        "transformations": [],
-        "type": "timeseries"
-      },
-      {
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "currencyUSD"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 0,
-          "y": 26
-        },
-        "id": 54,
-        "options": {
-          "displayMode": "gradient",
-          "orientation": "vertical",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showUnfilled": false
-        },
-        "pluginVersion": "8.4.2",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": false,
-            "expr": "sort_desc(\n  sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (\n    sum_over_time(\n      (\n        zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:spot_idle_cpu_cost\n        OR\n        capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:on_demand_idle_cpu_cost\n        OR\n        zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:spot_idle_mem_cost\n        OR\n        capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:on_demand_idle_mem_cost\n      )\n    [1d:1h])\n)\n)",
-            "format": "time_series",
-            "instant": true,
-            "interval": "",
-            "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
-            "refId": "A"
-          }
-        ],
-        "title": "Daily Idle Cost per Instance Type and Capacity Type",
-        "transformations": [],
-        "type": "bargauge"
-      },
-      {
-        "datasource": "${DS_PROMETHEUS}",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "currencyEUR"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 12,
-          "y": 26
-        },
-        "id": 51,
-        "options": {
-          "legend": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "displayMode": "table",
-            "placement": "right",
-            "sortBy": "Last *",
-            "sortDesc": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "8.2.3",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": true,
-            "expr": "sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (\n  sum_over_time(\n    (\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:spot_idle_cpu_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:on_demand_idle_cpu_cost\n      OR\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:spot_idle_mem_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:on_demand_idle_mem_cost\n    )\n  [1d:1h])\n)",
-            "hide": false,
-            "instant": false,
-            "interval": "",
-            "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
-            "refId": "A"
-          },
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": true,
-            "expr": "sum (\n  sum_over_time(\n    (\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:spot_idle_cpu_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:on_demand_idle_cpu_cost\n      OR\n      zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:spot_idle_mem_cost\n      OR\n      capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:on_demand_idle_mem_cost\n    )\n  [1d:1h])\n)",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Total",
-            "refId": "B"
-          }
-        ],
-        "title": "Daily Idle Cost per Instance and Capacity Type",
-        "transformations": [],
-        "type": "timeseries"
-      },
-      {
-        "description": "",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "currencyUSD"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 0,
-          "y": 35
-        },
-        "id": 59,
-        "options": {
-          "displayMode": "gradient",
-          "orientation": "vertical",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showUnfilled": false
-        },
-        "pluginVersion": "8.4.2",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": false,
-            "expr": "sort_desc (\n  sum_over_time(\n      sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (\n      \n\t      # See description for label_replace\n\t      label_replace(\n\t          ((\n\t              zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n\t              - \n\t              zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n\t          ) > 0)\n\t          OR\n\t          ((\n\t              capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n\t              -\n\t              capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n\t          ) > 0)\n\t      , \"resource\", \"CPU\", \"\",\"\")\n\t      \n\t      OR \n\t      \n\t      label_replace(\n\t          ((\n\t              zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n\t              -\n\t              zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n\t          ) > 0)\n\t          OR\n\t          ((\n\t              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n\t              -\n\t              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n\t          ) > 0)\n\t      , \"resource\", \"memory\", \"\",\"\")\n\n    )\n  [1d:1h])\n)",
-            "format": "time_series",
-            "instant": true,
-            "interval": "",
-            "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
-            "refId": "A"
-          }
-        ],
-        "title": "Daily Underutilization Cost per Instance Type and Capacity Type",
-        "transformations": [],
-        "type": "bargauge"
-      },
-      {
-        "description": "label_replace is used to ALWAYS have a different label (resource) when doing OR, so that no time series is filtered by binary operations (capacity_type for internal OR, resource for external OR)\n\nIf for example a pod has CPU requests but not memory requests, the binary sum (+) will filter the CPU sum (will not count for them)",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "currencyUSD"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 12,
-          "y": 35
-        },
-        "id": 47,
-        "options": {
-          "legend": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "displayMode": "table",
-            "placement": "right",
-            "sortBy": "Last *",
-            "sortDesc": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "8.3.1",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": true,
-            "expr": "sum_over_time(\n  sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (\n  \n      # See description for label_replace\n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n              - \n              zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n          ) > 0)\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n              -\n              zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n          ) > 0)\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])",
-            "format": "time_series",
-            "instant": false,
-            "interval": "",
-            "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
-            "refId": "A"
-          },
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": true,
-            "expr": "sum_over_time(\n  sum (\n  \n      # See description for label_replace\n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n              - \n              zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n          ) > 0)\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n              -\n              zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n          ) > 0)\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Total",
-            "refId": "B"
-          }
-        ],
-        "title": "Daily Underutilization Cost per Instance Type and Capacity Type",
-        "transformations": [],
-        "type": "timeseries"
-      },
-      {
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "currencyUSD"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 0,
-          "y": 44
-        },
-        "id": 55,
-        "options": {
-          "displayMode": "gradient",
-          "orientation": "vertical",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showUnfilled": false
-        },
-        "pluginVersion": "8.4.2",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": false,
-            "expr": "sort_desc(\n  sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (\n    sum_over_time(\n      (\n            zone_capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:spot_shared_cpu_cost\n            OR\n            capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:on_demand_shared_cpu_cost\n            OR\n            zone_capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:spot_shared_mem_cost\n            OR\n            capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:on_demand_shared_mem_cost\n      )\n    [1d:1h])\n  )\n)",
-            "format": "time_series",
-            "instant": true,
-            "interval": "",
-            "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
-            "refId": "A"
-          }
-        ],
-        "title": "Daily Shared Cost per Instance Type and Capacity Type",
-        "transformations": [],
-        "type": "bargauge"
-      },
-      {
-        "datasource": "${DS_PROMETHEUS}",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "palette-classic"
-            },
-            "custom": {
-              "axisLabel": "",
-              "axisPlacement": "auto",
-              "barAlignment": 0,
-              "drawStyle": "line",
-              "fillOpacity": 0,
-              "gradientMode": "none",
-              "hideFrom": {
-                "legend": false,
-                "tooltip": false,
-                "viz": false
-              },
-              "lineInterpolation": "linear",
-              "lineWidth": 1,
-              "pointSize": 5,
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "showPoints": "auto",
-              "spanNulls": false,
-              "stacking": {
-                "group": "A",
-                "mode": "none"
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "currencyEUR"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 12,
-          "y": 44
-        },
-        "id": 50,
-        "options": {
-          "legend": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "displayMode": "table",
-            "placement": "right",
-            "sortBy": "Last *",
-            "sortDesc": true
-          },
-          "tooltip": {
-            "mode": "single",
-            "sort": "none"
-          }
-        },
-        "pluginVersion": "8.2.3",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": true,
-            "expr": "sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (\n  sum_over_time(\n    (\n          zone_capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:spot_shared_cpu_cost\n          OR\n          capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:on_demand_shared_cpu_cost\n          OR\n          zone_capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:spot_shared_mem_cost\n          OR\n          capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:on_demand_shared_mem_cost\n    )\n  [1d:1h])\n)",
-            "hide": false,
-            "instant": false,
-            "interval": "",
-            "legendFormat": "{{label_beta_kubernetes_io_instance_type}}-{{label_eks_amazonaws_com_capacity_type}}",
-            "refId": "A"
-          },
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": true,
-            "expr": "sum (\n  sum_over_time(\n    (\n          zone_capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:spot_shared_cpu_cost\n          OR\n          capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:on_demand_shared_cpu_cost\n          OR\n          zone_capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:spot_shared_mem_cost\n          OR\n          capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:on_demand_shared_mem_cost\n    )\n  [1d:1h])\n)",
-            "hide": false,
-            "interval": "",
-            "legendFormat": "Total",
-            "refId": "B"
-          }
-        ],
-        "title": "Daily Shared Cost per Instance and Capacity Type",
-        "transformations": [],
-        "type": "timeseries"
-      },
-      {
-        "description": "label_replace is used to ALWAYS have a different label (resource) when doing OR, so that no time series is filtered by binary operations (capacity_type for internal OR, resource for external OR)\n\nIf for example a pod has CPU requests but not memory requests, the binary sum (+) will filter the CPU sum (will not count for them)",
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "decimals": 2,
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 80
-                }
-              ]
-            },
-            "unit": "currencyUSD"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 9,
-          "w": 24,
-          "x": 0,
-          "y": 53
-        },
-        "id": 74,
-        "options": {
-          "displayMode": "gradient",
-          "orientation": "vertical",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showUnfilled": false
-        },
-        "pluginVersion": "8.4.2",
-        "targets": [
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "exemplar": false,
-            "expr": "sort_desc (\nsum_over_time(\n  sum by (namespace) (\n  \n      # See description for label_replace\n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n              - \n              zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n          ) > 0)\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n              -\n              zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n          ) > 0)\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])\n)",
-            "format": "time_series",
-            "instant": true,
-            "interval": "",
-            "legendFormat": "{{namespace}}",
-            "refId": "A"
-          }
-        ],
-        "title": "Daily Total Cost per Namespace",
-        "transformations": [
-          {
-            "id": "seriesToColumns",
-            "options": {
-              "byField": "Time"
-            }
-          },
-          {
-            "id": "organize",
-            "options": {
-              "excludeByName": {
-                "Time": true
-              },
-              "indexByName": {},
-              "renameByName": {
-                "Value #A": "CPU Cost Per Day"
-              }
-            }
-          },
-          {
-            "id": "sortBy",
-            "options": {
-              "fields": {},
-              "sort": [
-                {
-                  "desc": true,
-                  "field": "CPU Cost Per Day"
-                }
-              ]
-            }
-          }
-        ],
-        "type": "bargauge"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 62
-        },
-        "id": 57,
-        "panels": [
-          {
-            "description": "label_replace is used to ALWAYS have a different label (resource) when doing OR, so that no time series is filtered by binary operations (capacity_type for internal OR, resource for external OR)\n\nIf for example a pod has CPU requests but not memory requests, the binary sum (+) will filter the CPU sum (will not count for them)",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "decimals": 2,
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 9,
-              "w": 24,
-              "x": 0,
-              "y": 2
-            },
-            "id": 79,
-            "options": {
-              "displayMode": "gradient",
-              "orientation": "vertical",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showUnfilled": false
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc (\nsum_over_time(\n  sum by (namespace) (\n  \n      # See description for label_replace\n      label_replace(\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n                > \n                zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n            )\n            OR\n            zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          )\n          OR\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n                >\n                capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n            )\n            OR\n            zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          )\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n                >\n                zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n            )\n            OR\n            zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n          )\n          OR\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n                >\n                capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n            ) \n            OR capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n          )\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])\n)",
-                "format": "time_series",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "{{namespace}}",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily Total Cost per Namespace",
-            "transformations": [
-              {
-                "id": "seriesToColumns",
-                "options": {
-                  "byField": "Time"
-                }
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value #A": "CPU Cost Per Day"
-                  }
-                }
-              },
-              {
-                "id": "sortBy",
-                "options": {
-                  "fields": {},
-                  "sort": [
-                    {
-                      "desc": true,
-                      "field": "CPU Cost Per Day"
-                    }
-                  ]
-                }
-              }
-            ],
-            "type": "bargauge"
-          },
-          {
-            "description": "label_replace is used to ALWAYS have a different label (resource) when doing OR, so that no time series is filtered by binary operations (capacity_type for internal OR, resource for external OR)\n\nIf for example a pod has CPU requests but not memory requests, the binary sum (+) will filter the CPU sum (will not count for them)",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "decimals": 2,
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 9,
-              "w": 24,
-              "x": 0,
-              "y": 11
-            },
-            "id": 63,
-            "options": {
-              "displayMode": "gradient",
-              "orientation": "vertical",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showUnfilled": false
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc (\nsum_over_time(\n  sum by (namespace) (\n  \n      # See description for label_replace\n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n              - \n              zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n          ) > 0)\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          ((\n              zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n              -\n              zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n          ) > 0)\n          OR\n          ((\n              capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n              -\n              capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n          ) > 0)\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])\n)",
-                "format": "time_series",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "{{namespace}}",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily Underutilization Cost per Namespace",
-            "transformations": [
-              {
-                "id": "seriesToColumns",
-                "options": {
-                  "byField": "Time"
-                }
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value #A": "CPU Cost Per Day"
-                  }
-                }
-              },
-              {
-                "id": "sortBy",
-                "options": {
-                  "fields": {},
-                  "sort": [
-                    {
-                      "desc": true,
-                      "field": "CPU Cost Per Day"
-                    }
-                  ]
-                }
-              }
-            ],
-            "type": "bargauge"
-          },
-          {
-            "description": "label_replace is used to ALWAYS have a different label (resource) when doing OR, so that no time series is filtered by binary operations (capacity_type for internal OR, resource for external OR)\n\nIf for example a pod has CPU requests but not memory requests, the binary sum (+) will filter the CPU sum (will not count for them)",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "decimals": 2,
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 9,
-              "w": 24,
-              "x": 0,
-              "y": 20
-            },
-            "id": 58,
-            "options": {
-              "displayMode": "gradient",
-              "orientation": "vertical",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showUnfilled": false
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc (\nsum_over_time(\n    sum by (namespace) (\n        # See description for label_replace\n        label_replace(\n\t\t    zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n            OR\n            capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n        , \"resource\", \"CPU\", \"\",\"\")\n        \n        OR \n        \n        label_replace(\n\t\t    zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n            OR\n            capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n        , \"resource\", \"memory\", \"\",\"\")\n\n\t)\n[1d:1h])\n)",
-                "format": "time_series",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "{{namespace}}",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily Requests Cost per Namespace",
-            "transformations": [
-              {
-                "id": "seriesToColumns",
-                "options": {
-                  "byField": "Time"
-                }
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value #A": "CPU Cost Per Day"
-                  }
-                }
-              },
-              {
-                "id": "sortBy",
-                "options": {
-                  "fields": {},
-                  "sort": [
-                    {
-                      "desc": true,
-                      "field": "CPU Cost Per Day"
-                    }
-                  ]
-                }
-              }
-            ],
-            "type": "bargauge"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 24,
-              "x": 0,
-              "y": 29
-            },
-            "id": 34,
-            "options": {
-              "displayMode": "gradient",
-              "orientation": "vertical",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showUnfilled": false
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc(\nsum_over_time(\n    sum by (namespace) (\n        # See description for label_replace\n        label_replace(\n\t\t    zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n            OR\n            capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n        , \"resource\", \"CPU\", \"\",\"\")\n        \n        OR \n        \n        label_replace(\n\t\t    zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n            OR\n            capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n        , \"resource\", \"memory\", \"\",\"\")\n\n\t)\n[1d:1h])\n)",
-                "format": "time_series",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "{{namespace}}",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily Usage Cost per Namespace ",
-            "transformations": [
-              {
-                "id": "seriesToColumns",
-                "options": {
-                  "byField": "Time"
-                }
-              }
-            ],
-            "type": "bargauge"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": false
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 8,
-              "x": 0,
-              "y": 37
-            },
-            "id": 65,
-            "options": {
-              "footer": {
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc(\n  sum_over_time(\n    sum by (namespace) (\n      label_replace(((\n          (sum by (namespace) (zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost))\n          -\n          (sum by (namespace) (zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost))\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (sum by (namespace) (capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost))\n          -\n          (sum by (namespace) (capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost))\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily CPU Underutilization Cost Per Namespace",
-            "transformations": [
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value #A": "Daily CPU Underutilization Cost",
-                    "namespace": "Namespace"
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": false
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 8,
-              "x": 8,
-              "y": 37
-            },
-            "id": 30,
-            "options": {
-              "footer": {
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc(\n\tsum_over_time(\n\t\tsum by (namespace) (\n\n\t\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost\n\t\t\tOR\n\t\t\tcapacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost\n\n\t\t)\n\t[1d:1h])\n)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily CPU Requests Cost Per Namespace",
-            "transformations": [
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value #A": "Daily CPU Requests Cost ",
-                    "namespace": "Namespace"
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": false
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 8,
-              "x": 16,
-              "y": 37
-            },
-            "id": 31,
-            "options": {
-              "footer": {
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc(\n\tsum_over_time(\n\t\tsum by (namespace) (\n\n\t\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost\n\t\t\tOR\n\t\t\tcapacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost\n\n\t\t)\n\t[1d:1h])\n)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily CPU Usage Cost Per Namespace ",
-            "transformations": [
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value #A": "Daily CPU Usage Cost",
-                    "namespace": "Namespace"
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": false
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 8,
-              "x": 0,
-              "y": 45
-            },
-            "id": 64,
-            "options": {
-              "footer": {
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc(\n  sum_over_time(\n    sum by (namespace) (\n      label_replace(((\n          (sum by (namespace) (zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost))\n          -\n          (sum by (namespace) (zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost))\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (sum by (namespace) (capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost))\n          -\n          (sum by (namespace) (capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost))\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily Memory Underutilization Cost Per Namespace",
-            "transformations": [
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value #A": "Daily Memory Underutilization Cost",
-                    "namespace": "Namespace"
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": false
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 8,
-              "x": 8,
-              "y": 45
-            },
-            "id": 35,
-            "options": {
-              "footer": {
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc(\n\tsum_over_time(\n\t\tsum by (namespace) (\n\n\t\t\tzone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost\n\t\t\tOR\n\t\t\tcapacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost\n\n\t\t)\n\t[1d:1h])\n)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily Memory Requests Cost per Namespace",
-            "transformations": [
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value #A": "Daily Memory Requests Cost",
-                    "namespace": "Namespace"
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": false
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 8,
-              "x": 16,
-              "y": 45
-            },
-            "id": 36,
-            "options": {
-              "footer": {
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc(\n\tsum_over_time(\n\t\tsum by (namespace) (\n\n\t\t\tzone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost\n\t\t\tOR\n\t\t\tcapacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost\n\n\t\t)\n\t[1d:1h])\n)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily Memory Usage Cost Per Namespace",
-            "transformations": [
-              {
-                "id": "seriesToColumns",
-                "options": {
-                  "byField": "Time"
-                }
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value #A": "Daily Memory Usage Cost",
-                    "namespace": "Namespace"
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "axisSoftMin": 0,
-                  "fillOpacity": 80,
-                  "gradientMode": "opacity",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineWidth": 1
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 24,
-              "x": 0,
-              "y": 53
-            },
-            "id": 38,
-            "options": {
-              "barWidth": 0.97,
-              "groupWidth": 0.7,
-              "legend": {
-                "calcs": [],
-                "displayMode": "table",
-                "placement": "bottom"
-              },
-              "orientation": "auto",
-              "showValue": "always",
-              "stacking": "normal",
-              "tooltip": {
-                "mode": "single"
-              },
-              "xTickLabelRotation": 0
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes/1024/1024/1024) * $pvcost)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "A"
-              }
-            ],
-            "title": "Monthly PVs Total Cost",
-            "transformations": [
-              {
-                "id": "seriesToColumns",
-                "options": {
-                  "byField": "Time"
-                }
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value #A": "PVCs Costs Per Day"
-                  }
-                }
-              },
-              {
-                "id": "sortBy",
-                "options": {
-                  "fields": {},
-                  "sort": [
-                    {
-                      "desc": true,
-                      "field": "PVCs Costs Per Day"
-                    }
-                  ]
-                }
-              }
-            ],
-            "type": "barchart"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 24,
-              "x": 0,
-              "y": 61
-            },
-            "id": 49,
-            "options": {
-              "legend": {
-                "calcs": [
-                  "last"
-                ],
-                "displayMode": "table",
-                "placement": "right",
-                "sortBy": "Last",
-                "sortDesc": true
-              },
-              "tooltip": {
-                "mode": "single"
-              }
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes/1024/1024/1024) * $pvcost)",
-                "format": "time_series",
-                "instant": false,
-                "interval": "",
-                "legendFormat": "{{namespace}}",
-                "refId": "A"
-              }
-            ],
-            "title": "Monthly PVs Total Cost",
-            "transformations": [],
-            "type": "timeseries"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "axisSoftMin": 0,
-                  "fillOpacity": 80,
-                  "gradientMode": "opacity",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineWidth": 1
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 0,
-              "y": 69
-            },
-            "id": 75,
-            "options": {
-              "barWidth": 0.97,
-              "groupWidth": 0.7,
-              "legend": {
-                "calcs": [],
-                "displayMode": "table",
-                "placement": "bottom"
-              },
-              "orientation": "auto",
-              "showValue": "always",
-              "stacking": "normal",
-              "tooltip": {
-                "mode": "single"
-              },
-              "xTickLabelRotation": 0
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "(sum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes/1024/1024/1024))\n-\nsum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes/1024/1024/1024))\n) * $pvcost",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "A"
-              }
-            ],
-            "title": "Monthly PVs Underutilization Cost",
-            "transformations": [
-              {
-                "id": "seriesToColumns",
-                "options": {
-                  "byField": "Time"
-                }
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value #A": "PVCs Costs Per Day"
-                  }
-                }
-              },
-              {
-                "id": "sortBy",
-                "options": {
-                  "fields": {},
-                  "sort": [
-                    {
-                      "desc": true,
-                      "field": "PVCs Costs Per Day"
-                    }
-                  ]
-                }
-              }
-            ],
-            "type": "barchart"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 12,
-              "y": 69
-            },
-            "id": 76,
-            "options": {
-              "legend": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "displayMode": "table",
-                "placement": "right",
-                "sortBy": "Last *",
-                "sortDesc": true
-              },
-              "tooltip": {
-                "mode": "single"
-              }
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "(sum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_capacity_bytes/1024/1024/1024))\n-\nsum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes/1024/1024/1024))\n) * $pvcost",
-                "format": "time_series",
-                "instant": false,
-                "interval": "",
-                "legendFormat": "{{namespace}}",
-                "refId": "A"
-              }
-            ],
-            "title": "Monthly PVs Underutilization Cost",
-            "transformations": [],
-            "type": "timeseries"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "axisSoftMin": 0,
-                  "fillOpacity": 80,
-                  "gradientMode": "opacity",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineWidth": 1
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 0,
-              "y": 77
-            },
-            "id": 77,
-            "options": {
-              "barWidth": 0.97,
-              "groupWidth": 0.7,
-              "legend": {
-                "calcs": [],
-                "displayMode": "table",
-                "placement": "bottom"
-              },
-              "orientation": "auto",
-              "showValue": "always",
-              "stacking": "normal",
-              "tooltip": {
-                "mode": "single"
-              },
-              "xTickLabelRotation": 0
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes/1024/1024/1024)) * $pvcost",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "A"
-              }
-            ],
-            "title": "Monthly PVs Usage Cost",
-            "transformations": [
-              {
-                "id": "seriesToColumns",
-                "options": {
-                  "byField": "Time"
-                }
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value #A": "PVCs Costs Per Day"
-                  }
-                }
-              },
-              {
-                "id": "sortBy",
-                "options": {
-                  "fields": {},
-                  "sort": [
-                    {
-                      "desc": true,
-                      "field": "PVCs Costs Per Day"
-                    }
-                  ]
-                }
-              }
-            ],
-            "type": "barchart"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 12,
-              "y": 77
-            },
-            "id": 78,
-            "options": {
-              "legend": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "displayMode": "table",
-                "placement": "right",
-                "sortBy": "Last *",
-                "sortDesc": true
-              },
-              "tooltip": {
-                "mode": "single"
-              }
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum by (namespace) (sum by (persistentvolumeclaim,namespace) (kubelet_volume_stats_used_bytes/1024/1024/1024)) * $pvcost",
-                "format": "time_series",
-                "instant": false,
-                "interval": "",
-                "legendFormat": "{{namespace}}",
-                "refId": "A"
-              }
-            ],
-            "title": "Monthly PVs Usage Cost",
-            "transformations": [],
-            "type": "timeseries"
-          }
-        ],
-        "title": "Namespace",
-        "type": "row"
-      },
-      {
-        "collapsed": true,
-        "gridPos": {
-          "h": 1,
-          "w": 24,
-          "x": 0,
-          "y": 63
-        },
-        "id": 10,
-        "panels": [
-          {
-            "description": "label_replace is used to ALWAYS have a different label (resource) when doing OR, so that no time series is filtered by binary operations (capacity_type for internal OR, resource for external OR)\n\nIf for example a pod has CPU requests but not memory requests, the binary sum (+) will filter the CPU sum (will not count for them)",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "decimals": 2,
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 9,
-              "w": 24,
-              "x": 0,
-              "y": 3
-            },
-            "id": 81,
-            "options": {
-              "displayMode": "gradient",
-              "orientation": "vertical",
-              "reduceOptions": {
-                "calcs": [
-                  "lastNotNull"
-                ],
-                "fields": "",
-                "values": false
-              },
-              "showUnfilled": false,
-              "text": {}
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc (\nsum_over_time(\n  sum by (pod) (\n  \n      # See description for label_replace\n      label_replace(\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n                > \n                zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n            )\n            OR\n            zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n          )\n          OR\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n                >\n                capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n            )\n            OR\n            zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n          )\n      , \"resource\", \"CPU\", \"\",\"\")\n      \n      OR \n      \n      label_replace(\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n                >\n                zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n            )\n            OR\n            zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n          )\n          OR\n          # If requests is bigger than usage, use requests. Otherwise use usage.\n          (\n            (\n                capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n                >\n                capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n            ) \n            OR capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n          )\n      , \"resource\", \"memory\", \"\",\"\")\n\n)\n[1d:1h])\n)",
-                "format": "time_series",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "{{namespace}}",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily Total Cost per Pod",
-            "transformations": [],
-            "type": "bargauge"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": false
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 8,
-              "x": 0,
-              "y": 12
-            },
-            "id": 71,
-            "options": {
-              "footer": {
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc(\n  sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n      label_replace(((\n          (zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost{namespace=\"$namespace\"})\n          -\n          (zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\"})\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost{namespace=\"$namespace\"})\n          -\n          (capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost{namespace=\"$namespace\"})\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily CPU Underutilization Costs Per Pod",
-            "transformations": [
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true,
-                    "label_beta_kubernetes_io_instance_type": true,
-                    "label_eks_amazonaws_com_capacity_type": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value": "Daily CPU Underutilization Cost ",
-                    "Value #A": "Daily CPU Underutilization Cost",
-                    "pod": "Pod"
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          },
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto"
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 8,
-              "x": 8,
-              "y": 12
-            },
-            "id": 68,
-            "options": {
-              "footer": {
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "showHeader": true
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc(\n    sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost{namespace=\"$namespace\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost{namespace=\"$namespace\"}\n\n\t)\n[1d:1h])\n)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily CPU Requests Costs Per Pod",
-            "transformations": [
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true,
-                    "label_beta_kubernetes_io_instance_type": true,
-                    "label_eks_amazonaws_com_capacity_type": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value": "Daily CPU Requests Costs",
-                    "Value #A": "Daily CPU Requests Costs",
-                    "pod": "Pod"
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          },
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto"
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 8,
-              "x": 16,
-              "y": 12
-            },
-            "id": 66,
-            "options": {
-              "footer": {
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "showHeader": true
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc(\n    sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost{namespace=\"$namespace\"}\n\n\t)\n[1d:1h])\n)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily CPU Usage Costs Per Pod",
-            "transformations": [
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true,
-                    "label_beta_kubernetes_io_instance_type": true,
-                    "label_eks_amazonaws_com_capacity_type": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value": "Daily CPU Usage Costs",
-                    "Value #A": "Daily CPU Usage Costs",
-                    "pod": "Pod"
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto",
-                  "filterable": false
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 7,
-              "w": 8,
-              "x": 0,
-              "y": 20
-            },
-            "id": 70,
-            "options": {
-              "footer": {
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "showHeader": true,
-              "sortBy": []
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc(\n  sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n      label_replace(((\n          (zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost{namespace=\"$namespace\"})\n          -\n          (zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\"})\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost{namespace=\"$namespace\"})\n          -\n          (capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\"})\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily Memory Underutilization Costs Per Pod",
-            "transformations": [
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true,
-                    "label_beta_kubernetes_io_instance_type": true,
-                    "label_eks_amazonaws_com_capacity_type": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value": "Daily Memory Underutilization Cost per Pod",
-                    "Value #A": "Daily Memory Underutilization Cost",
-                    "pod": "Pod"
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          },
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto"
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 7,
-              "w": 8,
-              "x": 8,
-              "y": 20
-            },
-            "id": 69,
-            "options": {
-              "footer": {
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "showHeader": true
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc(\nsum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost{namespace=\"$namespace\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost{namespace=\"$namespace\"}\n\n\t)\n[1d:1h])\n)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}} ",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily Memory Requests Costs Per Pod",
-            "transformations": [
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true,
-                    "label_beta_kubernetes_io_instance_type": true,
-                    "label_eks_amazonaws_com_capacity_type": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value": "Daily Memory Requests Cost",
-                    "Value #A": "Daily Memory Requests Costs",
-                    "pod": "Pod"
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          },
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto"
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 7,
-              "w": 8,
-              "x": 16,
-              "y": 20
-            },
-            "id": 67,
-            "options": {
-              "footer": {
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "showHeader": true
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sort_desc(\nsum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\"}\n\n\t)\n[1d:1h])\n)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}} ",
-                "refId": "A"
-              }
-            ],
-            "title": "Daily Memory Usage Costs Per Pod",
-            "transformations": [
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true,
-                    "label_beta_kubernetes_io_instance_type": true,
-                    "label_eks_amazonaws_com_capacity_type": true
-                  },
-                  "indexByName": {},
-                  "renameByName": {
-                    "Value": "Daily Memory Usage Cost",
-                    "Value #A": "Daily Memory Usage Costs",
-                    "pod": "Pod"
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          },
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                }
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 0,
-              "y": 27
-            },
-            "id": 11,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom"
-              },
-              "tooltip": {
-                "mode": "single"
-              }
-            },
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, pod) (\n    sum by (pod, node) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~\"$namespace\", pod=~\"$pod\"})\n    * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) \n    sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job=\"kube-state-metrics\"})\n)",
-                "instant": false,
-                "interval": "",
-                "legendFormat": "CPU Usage - {{pod}}",
-                "refId": "A"
-              },
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, pod) (\n    cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=~\"$namespace\", pod=~\"$pod\"}\n    * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) \n    sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job=\"kube-state-metrics\"})\n)",
-                "hide": false,
-                "interval": "",
-                "legendFormat": "CPU Requests - {{pod}}",
-                "refId": "B"
-              }
-            ],
-            "title": "CPU Requests vs Usage Per Pod",
-            "transformations": [],
-            "type": "timeseries"
-          },
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "bytes"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 12,
-              "y": 27
-            },
-            "id": 12,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom"
-              },
-              "tooltip": {
-                "mode": "single"
-              }
-            },
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, pod) (\n  sum by (pod, node) (container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$pod\", name!=\"\"})\n  * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) \n  sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job=\"kube-state-metrics\"})\n)",
-                "instant": false,
-                "interval": "",
-                "legendFormat": "Memory Usage - {{pod}} ",
-                "refId": "A"
-              },
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, pod) (\n    cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=~\"$namespace\", pod=~\"$pod\"}\n    * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) \n    sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job=\"kube-state-metrics\"})\n)",
-                "hide": false,
-                "interval": "",
-                "legendFormat": "Memory Requests - {{pod}} ",
-                "refId": "B"
-              }
-            ],
-            "title": "Memory Requests vs Usage Per Pod",
-            "transformations": [],
-            "type": "timeseries"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 0,
-              "y": 35
-            },
-            "id": 72,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom"
-              },
-              "tooltip": {
-                "mode": "single"
-              }
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sort_desc(\n  sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n      label_replace(((\n          (zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
-                "interval": "",
-                "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
-                "refId": "A"
-              },
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sort_desc(\n  sum_over_time(\n\tsum (\n      label_replace(((\n          (zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
-                "hide": false,
-                "interval": "",
-                "legendFormat": "Total",
-                "refId": "B"
-              }
-            ],
-            "title": "Daily CPU Underutilization Costs Per Pod",
-            "type": "timeseries"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 12,
-              "y": 35
-            },
-            "id": 73,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom"
-              },
-              "tooltip": {
-                "mode": "single"
-              }
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sort_desc(\n  sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n      label_replace(((\n          (zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
-                "interval": "",
-                "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
-                "refId": "A"
-              },
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sort_desc(\n  sum_over_time(\n\tsum (\n      label_replace(((\n          (zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"SPOT\", \"\",\"\")\n      OR\n      label_replace(((\n          (capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n          -\n          (capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"})\n      ) > 0), \"cap\", \"ON_DEMAND\", \"\",\"\")\n  )[1d:1h])\n)",
-                "hide": false,
-                "interval": "",
-                "legendFormat": "Total",
-                "refId": "B"
-              }
-            ],
-            "title": "Daily Memory Underutilization Costs Per Pod",
-            "type": "timeseries"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 0,
-              "y": 43
-            },
-            "id": 39,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom"
-              },
-              "tooltip": {
-                "mode": "single"
-              }
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
-                "interval": "",
-                "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
-                "refId": "A"
-              },
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum_over_time(\n\tsum (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
-                "hide": false,
-                "interval": "",
-                "legendFormat": "Total",
-                "refId": "B"
-              }
-            ],
-            "title": "Daily CPU Requests Cost Per Pod",
-            "type": "timeseries"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 12,
-              "y": 43
-            },
-            "id": 40,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom"
-              },
-              "tooltip": {
-                "mode": "single"
-              }
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
-                "interval": "",
-                "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
-                "refId": "A"
-              },
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum_over_time(\n\tsum (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
-                "hide": false,
-                "interval": "",
-                "legendFormat": "Total",
-                "refId": "B"
-              }
-            ],
-            "title": "Daily Memory Requests Cost Per Pod",
-            "type": "timeseries"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 0,
-              "y": 51
-            },
-            "id": 41,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom"
-              },
-              "tooltip": {
-                "mode": "single"
-              }
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
-                "interval": "",
-                "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
-                "refId": "A"
-              },
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum_over_time(\n\tsum (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
-                "hide": false,
-                "interval": "",
-                "legendFormat": "Total",
-                "refId": "B"
-              }
-            ],
-            "title": "Daily CPU Usage Cost Per Pod",
-            "type": "timeseries"
-          },
-          {
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "currencyUSD"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 12,
-              "x": 12,
-              "y": 51
-            },
-            "id": 42,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom"
-              },
-              "tooltip": {
-                "mode": "single"
-              }
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum_over_time(\n\tsum by (label_beta_kubernetes_io_instance_type, label_eks_amazonaws_com_capacity_type, pod) (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
-                "interval": "",
-                "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_eks_amazonaws_com_capacity_type}} - {{pod}}",
-                "refId": "A"
-              },
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum_over_time(\n\tsum (\n\n\t\tzone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\t\tOR\n\t\tcapacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost{namespace=\"$namespace\", pod=~\"$pod\"}\n\n\t)\n[1d:1h])",
-                "hide": false,
-                "interval": "",
-                "legendFormat": "Total",
-                "refId": "B"
-              }
-            ],
-            "title": "Daily Memory Usage Cost Per Pod",
-            "type": "timeseries"
-          },
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "thresholds"
-                },
-                "custom": {
-                  "align": "auto",
-                  "displayMode": "auto"
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "decgbytes"
-              },
-              "overrides": [
-                {
-                  "matcher": {
-                    "id": "byRegexp",
-                    "options": ".*Cost"
-                  },
-                  "properties": [
-                    {
-                      "id": "unit",
-                      "value": "currencyUSD"
-                    }
-                  ]
-                },
-                {
-                  "matcher": {
-                    "id": "byName",
-                    "options": "PVC (Persistent Volume Claim)"
-                  },
-                  "properties": [
-                    {
-                      "id": "custom.width",
-                      "value": 554
-                    }
-                  ]
-                }
-              ]
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 24,
-              "x": 0,
-              "y": 59
-            },
-            "id": 8,
-            "options": {
-              "footer": {
-                "fields": "",
-                "reducer": [
-                  "sum"
-                ],
-                "show": false
-              },
-              "frameIndex": 0,
-              "showHeader": true,
-              "sortBy": [
-                {
-                  "desc": true,
-                  "displayName": "Underutilization Cost"
-                }
-              ]
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
-                "format": "table",
-                "instant": true,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{persistentvolumeclaim}}",
-                "refId": "A"
-              },
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
-                "format": "table",
-                "hide": false,
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "C"
-              },
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)\n-\nsum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
-                "format": "table",
-                "hide": false,
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "D"
-              },
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024) * $pvcost",
-                "format": "table",
-                "hide": false,
-                "instant": true,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "",
-                "refId": "B"
-              },
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\"}/1024/1024/1024) * $pvcost",
-                "format": "table",
-                "hide": false,
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "E"
-              },
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": false,
-                "expr": "(sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)\n-\nsum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\"}/1024/1024/1024))\n* $pvcost",
-                "format": "table",
-                "hide": false,
-                "instant": true,
-                "interval": "",
-                "legendFormat": "",
-                "refId": "F"
-              }
-            ],
-            "title": "Monthly PV Cost Per Pod",
-            "transformations": [
-              {
-                "id": "sortBy",
-                "options": {
-                  "fields": {},
-                  "sort": [
-                    {
-                      "desc": true,
-                      "field": "Value #A"
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "seriesToColumns",
-                "options": {
-                  "byField": "persistentvolumeclaim"
-                }
-              },
-              {
-                "id": "organize",
-                "options": {
-                  "excludeByName": {
-                    "Time": true,
-                    "persistentvolumeclaim 2": true
-                  },
-                  "indexByName": {
-                    "Time": 1,
-                    "Value #A": 2,
-                    "Value #B": 3,
-                    "Value #C": 4,
-                    "Value #D": 6,
-                    "Value #E": 5,
-                    "persistentvolumeclaim": 0
-                  },
-                  "renameByName": {
-                    "Value": "Cost",
-                    "Value #A": "Size",
-                    "Value #B": "Total Cost",
-                    "Value #C": "Used",
-                    "Value #D": "Free",
-                    "Value #E": "Usage Cost",
-                    "Value #F": "Underutilization Cost",
-                    "persistentvolumeclaim": "PVC (Persistent Volume Claim)"
-                  }
-                }
-              }
-            ],
-            "type": "table"
-          },
-          {
-            "datasource": "${DS_PROMETHEUS}",
-            "fieldConfig": {
-              "defaults": {
-                "color": {
-                  "mode": "palette-classic"
-                },
-                "custom": {
-                  "axisLabel": "",
-                  "axisPlacement": "auto",
-                  "barAlignment": 0,
-                  "drawStyle": "line",
-                  "fillOpacity": 0,
-                  "gradientMode": "none",
-                  "hideFrom": {
-                    "legend": false,
-                    "tooltip": false,
-                    "viz": false
-                  },
-                  "lineInterpolation": "linear",
-                  "lineWidth": 1,
-                  "pointSize": 5,
-                  "scaleDistribution": {
-                    "type": "linear"
-                  },
-                  "showPoints": "auto",
-                  "spanNulls": false,
-                  "stacking": {
-                    "group": "A",
-                    "mode": "none"
-                  },
-                  "thresholdsStyle": {
-                    "mode": "off"
-                  }
-                },
-                "mappings": [],
-                "thresholds": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green"
-                    },
-                    {
-                      "color": "red",
-                      "value": 80
-                    }
-                  ]
-                },
-                "unit": "decgbytes"
-              },
-              "overrides": []
-            },
-            "gridPos": {
-              "h": 8,
-              "w": 24,
-              "x": 0,
-              "y": 67
-            },
-            "id": 82,
-            "options": {
-              "legend": {
-                "calcs": [],
-                "displayMode": "list",
-                "placement": "bottom"
-              },
-              "tooltip": {
-                "mode": "single"
-              }
-            },
-            "pluginVersion": "8.3.1",
-            "targets": [
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\", persistentvolumeclaim=~\"$pvc\"}/1024/1024/1024)",
-                "format": "time_series",
-                "instant": false,
-                "interval": "",
-                "intervalFactor": 1,
-                "legendFormat": "{{persistentvolumeclaim}} - Capacity",
-                "refId": "A"
-              },
-              {
-                "datasource": "${DS_PROMETHEUS}",
-                "exemplar": true,
-                "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_used_bytes{namespace=~\"${namespace}\", persistentvolumeclaim=~\"$pvc\"}/1024/1024/1024)",
-                "format": "time_series",
-                "hide": false,
-                "instant": false,
-                "interval": "",
-                "legendFormat": "{{persistentvolumeclaim}} - Usage",
-                "refId": "C"
-              }
-            ],
-            "title": "PV Capacity vs Usage",
-            "transformations": [],
-            "type": "timeseries"
-          }
-        ],
-        "title": "Pod Per Namespace",
-        "type": "row"
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
       }
-    ],
-    "refresh": "5m",
-    "schemaVersion": 35,
-    "style": "dark",
-    "tags": [],
-    "templating": {
-      "list": [
-        {
-          "current": {
-            "selected": false,
-            "text": "Prometheus",
-            "value": "Prometheus"
-          },
-          "hide": 0,
-          "includeAll": false,
-          "label": "Prometheus Datasource",
-          "multi": false,
-          "name": "DS_PROMETHEUS",
-          "options": [],
-          "query": "prometheus",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "type": "datasource"
-        },
-        {
-          "hide": 2,
-          "name": "region",
-          "query": "eu-west-1",
-          "skipUrlSync": false,
-          "type": "constant"
-        },
-        {
-          "current": {
-            "selected": false,
-            "text": "velero",
-            "value": "velero"
-          },
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "definition": "label_values(kube_pod_info, namespace)",
-          "hide": 0,
-          "includeAll": false,
-          "multi": false,
-          "name": "namespace",
-          "options": [],
-          "query": {
-            "query": "label_values(kube_pod_info, namespace)",
-            "refId": "StandardVariableQuery"
-          },
-          "refresh": 2,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 1,
-          "type": "query"
-        },
-        {
-          "current": {
-            "selected": true,
-            "text": [
-              "All"
-            ],
-            "value": [
-              "$__all"
-            ]
-          },
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "definition": "label_values(kube_pod_info{namespace=\"$namespace\"}, pod)",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Pod",
-          "multi": true,
-          "name": "pod",
-          "options": [],
-          "query": {
-            "query": "label_values(kube_pod_info{namespace=\"$namespace\"}, pod)",
-            "refId": "StandardVariableQuery"
-          },
-          "refresh": 2,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 1,
-          "type": "query"
-        },
-        {
-          "description": "Price of GiB per month",
-          "hide": 2,
-          "label": "PV Cost GB/month",
-          "name": "pvcost",
-          "query": "0.089",
-          "skipUrlSync": false,
-          "type": "constant"
-        },
-        {
-          "current": {
-            "selected": true,
-            "text": [
-              "All"
-            ],
-            "value": [
-              "$__all"
-            ]
-          },
-          "definition": "label_values(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"}, persistentvolumeclaim)",
-          "hide": 0,
-          "includeAll": true,
-          "label": "Persistent Volume Claim",
-          "multi": true,
-          "name": "pvc",
-          "options": [],
-          "query": {
-            "query": "label_values(kubelet_volume_stats_capacity_bytes{namespace=\"$namespace\"}, persistentvolumeclaim)",
-            "refId": "StandardVariableQuery"
-          },
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "sort": 1,
-          "type": "query"
-        }
-      ]
-    },
-    "time": {
-      "from": "now-24h",
-      "to": "now"
-    },
-    "timepicker": {},
-    "timezone": "",
-    "title": "Kubernetes Cost Report",
-    "uid": "ZudkNFhnksaf",
-    "version": 1,
-    "weekStart": ""
-  }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Kubernetes Cost Report",
+  "uid": "ZudkNFhnksaf",
+  "version": 4,
+  "weekStart": ""
+}

--- a/charts/kubernetes-cost-report/templates/prometheusrules.yaml
+++ b/charts/kubernetes-cost-report/templates/prometheusrules.yaml
@@ -15,126 +15,126 @@ spec:
     rules:
     - expr: |-
         (
-          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (kube_node_labels{job="kube-state-metrics"}) 
-          * on (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) 
-          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_cost_all{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
+          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (kube_node_labels{job="kube-state-metrics"}) 
+          * on (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) 
+          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_cost_all{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
         )
       record: zone_capacity_instance:spot_instance_cost:cost
     - expr: |-
-        sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
+        sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
         (
           zone_capacity_instance:spot_instance_cost:cost
         )
       record: capacity_instance:spot_instance_cost:cost
     - expr: |-
         (
-          sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (kube_node_labels{job="kube-state-metrics"}) 
-          * on (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) 
-          sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_cost_all{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+          sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (kube_node_labels{job="kube-state-metrics"}) 
+          * on (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) 
+          sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_cost_all{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
         )
       record: capacity_instance:on_demand_instance_cost:cost
     - expr: |-
         (
           (
             (sum by(namespace, node, pod) (cluster:namespace:pod_memory:active:kube_pod_container_resource_requests) /1024/1024/1024) 
-            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
-            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="SPOT"})
+            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
+            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="SPOT"})
           )
 
-          * ignoring(namespace, node, pod) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) 
+          * ignoring(namespace, node, pod) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) 
 
-          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
+          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
         )
       record: zone_capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:spot_pod_mem_requests_cost
     - expr: |-
         (
           (
             (sum by(namespace, node, pod) (cluster:namespace:pod_memory:active:kube_pod_container_resource_requests) /1024/1024/1024) 
-            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
-            sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
+            sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
           )
 
-          * ignoring(namespace, node, pod) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) 
+          * ignoring(namespace, node, pod) group_left(label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) 
 
-          sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+          sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
         )
       record: capacity_instance_namespace_node_pod:pod_memory_requests_instance_mem_price:on_demand_pod_mem_requests_cost
     - expr: |-
         (
           (
             sum by(namespace, node, pod) (cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests) 
-            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
-            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{label_eks_amazonaws_com_capacity_type="SPOT"})
+            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
+            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{label_eks_amazonaws_com_capacity_type="SPOT"})
           )
 
-          * ignoring(namespace, node, pod) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) 
+          * ignoring(namespace, node, pod) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) 
 
-          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_cpu_price{label_eks_amazonaws_com_capacity_type="SPOT"})
+          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_cpu_price{label_eks_amazonaws_com_capacity_type="SPOT"})
         )
       record: zone_capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:spot_pod_cpu_requests_cost
     - expr: |-
         (
           (
             sum by(namespace, node, pod) (cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests) 
-            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
-            sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
+            sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
           )
 
-          * ignoring(namespace, node, pod) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) 
+          * ignoring(namespace, node, pod) group_left(label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) 
 
-          sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_cpu_price{label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+          sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_cpu_price{label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
         )
       record: capacity_instance_namespace_node_pod:pod_cpu_requests_instance_cpu_price:on_demand_pod_cpu_requests_cost
     - expr: |-
         (
           (
             (sum by (namespace, node, pod) (container_memory_working_set_bytes{name!=""}) /1024/1024/1024)
-            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
-            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="SPOT"})
+            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
+            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="SPOT"})
           )
 
-          * ignoring(namespace, node, pod) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) 
+          * ignoring(namespace, node, pod) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) 
 
-          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
+          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
         )
       record: zone_capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:spot_pod_mem_usage_cost
     - expr: |-
         (
           (
             (sum by (namespace, node, pod) (container_memory_working_set_bytes{name!=""}) /1024/1024/1024)
-            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
-            sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
+            sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
           )
 
-          * ignoring(namespace, node, pod) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) 
+          * ignoring(namespace, node, pod) group_left(label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) 
 
-          sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+          sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
         )
       record: capacity_instance_namespace_node_pod:pod_memory_usage_instance_mem_price:on_demand_pod_mem_usage_cost
     - expr: |-
         (
           (
             sum by(namespace, node, pod) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) 
-            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
-            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="SPOT"})
+            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
+            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="SPOT"})
           )
 
-          * ignoring(namespace, node, pod) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) 
+          * ignoring(namespace, node, pod) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) 
 
-          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_cpu_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
+          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_cpu_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
         )
       record: zone_capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:spot_pod_cpu_usage_cost
     - expr: |-
         (
           (
             sum by(namespace, node, pod) (node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate) 
-            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
-            sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
+            sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
           )
 
-          * ignoring(namespace, node, pod) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) 
+          * ignoring(namespace, node, pod) group_left(label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) 
 
-          sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_cpu_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+          sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_cpu_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
         )
       record: capacity_instance_namespace_node_pod:pod_cpu_usage_instance_cpu_price:on_demand_pod_cpu_usage_cost
     - expr: |-
@@ -148,14 +148,14 @@ spec:
               )
             )
 
-            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
+            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
             
-            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="SPOT"})
+            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="SPOT"})
           )
 
           * ignoring (node, resource) group_left
 
-          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_cpu_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
+          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_cpu_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
 
         )
       record: zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:spot_idle_cpu_cost
@@ -170,14 +170,14 @@ spec:
               )
             )
 
-            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
+            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
             
-            sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+            sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
           )
 
           * ignoring (node, resource) group_left
 
-          sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_cpu_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+          sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_cpu_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
 
         )
       record: capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_cpu_price:on_demand_idle_cpu_cost
@@ -193,14 +193,14 @@ spec:
               /1024/1024/1024
             )
 
-            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
+            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
             
-            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="SPOT"})
+            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="SPOT"})
           )
 
           * ignoring (node, resource) group_left
 
-          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
+          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
 
         )
       record: zone_capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:spot_idle_mem_cost
@@ -216,14 +216,14 @@ spec:
               /1024/1024/1024
             )
 
-            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
+            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
             
-            sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+            sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
           )
 
           * ignoring (node, resource) group_left
 
-          sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+          sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
 
         )
       record: capacity_instance_node_resource:kube_node_status_allocatable_idle_instance_mem_price:on_demand_idle_mem_cost
@@ -238,14 +238,14 @@ spec:
               )
             ) 
             
-            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
+            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
             
-            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="SPOT"})
+            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="SPOT"})
           )
 
-          * ignoring(node, resource) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) 
+          * ignoring(node, resource) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) 
 
-          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_cpu_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
+          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_cpu_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
         )
       record: zone_capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:spot_shared_cpu_cost
     - expr: |-
@@ -259,14 +259,14 @@ spec:
               )
             ) 
             
-            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
+            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
             
-            sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+            sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
           )
 
-          * ignoring(node, resource) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) 
+          * ignoring(node, resource) group_left(label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) 
 
-          sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_cpu_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+          sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_cpu_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
         )
       record: capacity_instance_node_resource:kube_node_status_shared_instance_cpu_price:on_demand_shared_cpu_cost
     - expr: |-
@@ -280,14 +280,14 @@ spec:
               )
             ) 
             
-            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
+            * on (node) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
             
-            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="SPOT"})
+            sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="SPOT"})
           )
 
-          * ignoring(node, resource) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) 
+          * ignoring(node, resource) group_left(label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) 
 
-          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
+          sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="SPOT"})
         )
       record: zone_capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:spot_shared_mem_cost
     - expr: |-
@@ -301,14 +301,14 @@ spec:
               )
             )
             
-            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type)
+            * on (node) group_left(label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type)
             
-            sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+            sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type, node) (kube_node_labels{job="kube-state-metrics", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
           )
 
-          * ignoring(node, resource) group_left(label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) 
+          * ignoring(node, resource) group_left(label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) 
 
-          sum by (label_eks_amazonaws_com_capacity_type, label_beta_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
+          sum by (label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_mem_price{job="kubernetes-cost-report", label_eks_amazonaws_com_capacity_type="ON_DEMAND"})
         )
       record: capacity_instance_node_resource:kube_node_status_shared_instance_mem_price:on_demand_shared_mem_cost
 {{- end }}

--- a/cloud/aws.go
+++ b/cloud/aws.go
@@ -52,7 +52,7 @@ type SpotUnitPrice struct {
 }
 
 const (
-	instanceType   = "label_beta_kubernetes_io_instance_type"
+	instanceType   = "label_node_kubernetes_io_instance_type"
 	instanceOption = "label_eks_amazonaws_com_capacity_type"
 	// CPU label.
 	CPU = "vcpu"

--- a/dashboard.json
+++ b/dashboard.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -21,13 +24,17 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 84,
-  "iteration": 1639663374971,
+  "id": 875,
+  "iteration": 1663753809845,
   "links": [],
   "liveNow": false,
   "panels": [
     {
       "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -36,11 +43,21 @@
       },
       "id": 19,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Cluster",
       "type": "row"
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "${promdatasource}"
       },
       "fieldConfig": {
@@ -81,8 +98,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -107,17 +123,33 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum(kube_node_labels{label_eks_amazonaws_com_capacity_type=\"SPOT\"}) by (label_beta_kubernetes_io_instance_type)",
           "instant": false,
           "interval": "",
           "legendFormat": "",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${promdatasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(kube_node_labels{label_eks_amazonaws_com_capacity_type=\"SPOT\"}) by (label_node_kubernetes_io_instance_type)",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Instance Type",
@@ -174,8 +206,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -201,7 +232,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "pluginVersion": "8.2.3",
@@ -230,6 +262,24 @@
           "interval": "",
           "legendFormat": "Total",
           "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${promdatasource}"
+          },
+          "expr": "sum_over_time((\n    \n    sum by (label_node_kubernetes_io_instance_type) (sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (kube_node_labels{job=\"kube-state-metrics\"}) * on (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_cost))\n\n)[1d:1h])",
+          "hide": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${promdatasource}"
+          },
+          "expr": "sum(\n    sum_over_time((sum by (label_node_kubernetes_io_instance_type) (sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (kube_node_labels{job=\"kube-state-metrics\"}) * on (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) sum by (label_topology_kubernetes_io_zone, label_eks_amazonaws_com_capacity_type, label_node_kubernetes_io_instance_type) (instance_cost))\n)[1d:1h])\n)",
+          "hide": false,
+          "refId": "D"
         }
       ],
       "title": "Cluster Cost per Day",
@@ -278,8 +328,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -305,11 +354,15 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum(irate(container_network_transmit_bytes_total[30m]))/(1024*1024*1024)",
           "instant": false,
@@ -325,6 +378,7 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "${promdatasource}"
       },
       "fieldConfig": {
@@ -337,8 +391,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -372,9 +425,12 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum_over_time(sum(irate(container_network_transmit_bytes_total[30m]))[$__range:])/(1024*1024*1024)*0.07",
           "format": "time_series",
@@ -400,15 +456,15 @@
           },
           "custom": {
             "align": "auto",
-            "displayMode": "auto"
+            "displayMode": "auto",
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -492,9 +548,12 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum (sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes/1024/1024/1024))",
           "format": "table",
@@ -505,6 +564,9 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum(sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes/1024/1024/1024) * 0.089)",
           "format": "table",
@@ -542,6 +604,10 @@
     },
     {
       "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -550,11 +616,21 @@
       },
       "id": 7,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Namespace",
       "type": "row"
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "${promdatasource}"
       },
       "fieldConfig": {
@@ -595,8 +671,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -621,17 +696,31 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum ((sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\"}) by (node)) * on (node ) group_left(label_beta_kubernetes_io_instance_type,label_topology_kubernetes_io_zone) sum(kube_node_labels) by (label_beta_kubernetes_io_instance_type,node, label_topology_kubernetes_io_zone))by (label_beta_kubernetes_io_instance_type,node,label_topology_kubernetes_io_zone)",
+          "hide": false,
           "instant": false,
           "interval": "",
           "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{label_topology_kubernetes_io_zone}} - {{node}}",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${promdatasource}"
+          },
+          "expr": "sum ((sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\"}) by (node)) * on (node ) group_left(label_node_kubernetes_io_instance_type,label_topology_kubernetes_io_zone) sum(kube_node_labels) by (label_node_kubernetes_io_instance_type,node, label_topology_kubernetes_io_zone))by (label_node_kubernetes_io_instance_type,node,label_topology_kubernetes_io_zone)",
+          "hide": false,
+          "refId": "B"
         }
       ],
       "title": "CPU Usage",
@@ -639,6 +728,10 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -649,8 +742,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -684,14 +776,28 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
           "exemplar": true,
           "expr": "sum ((sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\"}) by (node)) * on (node ) group_left(label_beta_kubernetes_io_instance_type) sum(kube_node_labels) by (label_beta_kubernetes_io_instance_type,node))by (label_beta_kubernetes_io_instance_type,node) * ${cpu_cost}",
+          "hide": false,
           "interval": "",
           "legendFormat": "",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum ((sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\"}) by (node)) * on (node ) group_left(label_node_kubernetes_io_instance_type) sum(kube_node_labels) by (label_node_kubernetes_io_instance_type,node))by (label_node_kubernetes_io_instance_type,node) * ${cpu_cost}",
+          "hide": false,
+          "refId": "B"
         }
       ],
       "title": "CPU Usage Cost",
@@ -699,6 +805,7 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "${promdatasource}"
       },
       "fieldConfig": {
@@ -739,8 +846,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -766,17 +872,30 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum ((sum(container_memory_working_set_bytes{namespace=~\"$namespace\", name!=\"\"}) by (node) ) * on (node ) group_left(label_beta_kubernetes_io_instance_type) sum(kube_node_labels) by (label_beta_kubernetes_io_instance_type,node))by (label_beta_kubernetes_io_instance_type,node)",
           "instant": false,
           "interval": "",
           "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{node}} ",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${promdatasource}"
+          },
+          "expr": "sum ((sum(container_memory_working_set_bytes{namespace=~\"$namespace\", name!=\"\"}) by (node) ) * on (node ) group_left(label_node_kubernetes_io_instance_type) sum(kube_node_labels) by (label_node_kubernetes_io_instance_type,node))by (label_node_kubernetes_io_instance_type,node)",
+          "hide": false,
+          "refId": "B"
         }
       ],
       "title": "Memory Usage",
@@ -785,6 +904,7 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "${promdatasource}"
       },
       "fieldConfig": {
@@ -797,8 +917,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -832,15 +951,28 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum ((sum(container_memory_working_set_bytes{namespace=~\"$namespace\", name!=\"\"}) by (node) ) * on (node ) group_left(label_beta_kubernetes_io_instance_type) sum(kube_node_labels) by (label_beta_kubernetes_io_instance_type,node))by (label_beta_kubernetes_io_instance_type,node)* ${memory_cost}",
+          "hide": false,
           "instant": false,
           "interval": "",
           "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{node}} ",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${promdatasource}"
+          },
+          "expr": "sum ((sum(container_memory_working_set_bytes{namespace=~\"$namespace\", name!=\"\"}) by (node) ) * on (node ) group_left(label_node_kubernetes_io_instance_type) sum(kube_node_labels) by (label_node_kubernetes_io_instance_type,node))by (label_node_kubernetes_io_instance_type,node)* ${memory_cost}",
+          "hide": false,
+          "refId": "B"
         }
       ],
       "title": "Memory Cost Usage",
@@ -849,6 +981,7 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "${promdatasource}"
       },
       "fieldConfig": {
@@ -889,8 +1022,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -916,18 +1048,32 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum ((sum(irate(container_network_transmit_bytes_total{namespace=~\"argo\"}[30m])) by (node)  ) * on (node ) group_left(label_beta_kubernetes_io_instance_type) sum(kube_node_labels) by (label_beta_kubernetes_io_instance_type,node))by (label_beta_kubernetes_io_instance_type,node)",
+          "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{node}}  ",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${promdatasource}"
+          },
+          "expr": "sum ((sum(irate(container_network_transmit_bytes_total{namespace=~\"argo\"}[30m])) by (node)  ) * on (node ) group_left(label_node_kubernetes_io_instance_type) sum(kube_node_labels) by (label_node_kubernetes_io_instance_type,node))by (label_node_kubernetes_io_instance_type,node)",
+          "hide": false,
+          "refId": "B"
         }
       ],
       "title": "Transmit Bandwidth",
@@ -945,15 +1091,15 @@
           },
           "custom": {
             "align": "auto",
-            "displayMode": "auto"
+            "displayMode": "auto",
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1037,9 +1183,12 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum (sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024))",
           "format": "table",
@@ -1050,6 +1199,9 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum(sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024) * 0.089)",
           "format": "table",
@@ -1087,6 +1239,10 @@
     },
     {
       "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1095,11 +1251,21 @@
       },
       "id": 10,
       "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
       "title": "Workloads",
       "type": "row"
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "${promdatasource}"
       },
       "fieldConfig": {
@@ -1140,8 +1306,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1166,17 +1331,31 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum (sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~\"argo\"}) by (pod,node) * on (node ) group_left(label_beta_kubernetes_io_instance_type) sum(kube_node_labels) by (label_beta_kubernetes_io_instance_type,node))by (label_beta_kubernetes_io_instance_type,pod)",
+          "hide": false,
           "instant": false,
           "interval": "",
           "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{pod}}",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${promdatasource}"
+          },
+          "expr": "sum (sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=~\"argo\"}) by (pod,node) * on (node ) group_left(label_node_kubernetes_io_instance_type) sum(kube_node_labels) by (label_node_kubernetes_io_instance_type,node))by (label_node_kubernetes_io_instance_type,pod)",
+          "hide": false,
+          "refId": "B"
         }
       ],
       "title": "CPU Usage",
@@ -1185,6 +1364,7 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "${promdatasource}"
       },
       "fieldConfig": {
@@ -1225,8 +1405,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1252,17 +1431,31 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum ((sum(container_memory_working_set_bytes{namespace=\"$namespace\", name!=\"\"}) by (pod,node) ) * on (node ) group_left(label_beta_kubernetes_io_instance_type) sum(kube_node_labels) by (label_beta_kubernetes_io_instance_type,node))by (label_beta_kubernetes_io_instance_type,node,pod)",
+          "hide": false,
           "instant": false,
           "interval": "",
           "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{pod}} ",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${promdatasource}"
+          },
+          "expr": "sum ((sum(container_memory_working_set_bytes{namespace=\"$namespace\", name!=\"\"}) by (pod,node) ) * on (node ) group_left(label_node_kubernetes_io_instance_type) sum(kube_node_labels) by (label_node_kubernetes_io_instance_type,node))by (label_node_kubernetes_io_instance_type,node,pod)",
+          "hide": false,
+          "refId": "B"
         }
       ],
       "title": "Memory Usage",
@@ -1271,6 +1464,7 @@
     },
     {
       "datasource": {
+        "type": "prometheus",
         "uid": "${promdatasource}"
       },
       "fieldConfig": {
@@ -1311,8 +1505,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1338,18 +1531,32 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum ((sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\"}[30m])) by (pod,node)  ) * on (node ) group_left(label_beta_kubernetes_io_instance_type) sum(kube_node_labels) by (label_beta_kubernetes_io_instance_type,node))by (label_beta_kubernetes_io_instance_type,node,pod)",
+          "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{label_beta_kubernetes_io_instance_type}} - {{pod}}  ",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${promdatasource}"
+          },
+          "expr": "sum ((sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\"}[30m])) by (pod,node)  ) * on (node ) group_left(label_node_kubernetes_io_instance_type) sum(kube_node_labels) by (label_node_kubernetes_io_instance_type,node))by (label_node_kubernetes_io_instance_type,node,pod)",
+          "hide": false,
+          "refId": "B"
         }
       ],
       "title": "Transmit Bandwidth",
@@ -1367,15 +1574,15 @@
           },
           "custom": {
             "align": "auto",
-            "displayMode": "auto"
+            "displayMode": "auto",
+            "inspect": false
           },
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1443,9 +1650,12 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "8.3.1",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024)",
           "format": "table",
@@ -1456,6 +1666,9 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "uid": "${promdatasource}"
+          },
           "exemplar": true,
           "expr": "sum by (persistentvolumeclaim) (kubelet_volume_stats_capacity_bytes{namespace=~\"${namespace}\"}/1024/1024/1024) * 0.089",
           "format": "table",
@@ -1508,7 +1721,7 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 33,
+  "schemaVersion": 36,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -1534,8 +1747,8 @@
       {
         "current": {
           "selected": false,
-          "text": "CloudWatch Test",
-          "value": "CloudWatch Test"
+          "text": "Master AWS CloudWatch",
+          "value": "Master AWS CloudWatch"
         },
         "hide": 0,
         "includeAll": false,
@@ -1559,10 +1772,9 @@
       },
       {
         "current": {
-          "isNone": true,
           "selected": false,
-          "text": "None",
-          "value": ""
+          "text": "kube-system",
+          "value": "kube-system"
         },
         "datasource": {
           "uid": "${promdatasource}"
@@ -1585,10 +1797,9 @@
       },
       {
         "current": {
-          "isNone": true,
           "selected": false,
-          "text": "None",
-          "value": ""
+          "text": "aws-node-rbgww",
+          "value": "aws-node-rbgww"
         },
         "datasource": {
           "uid": "${promdatasource}"
@@ -1613,10 +1824,13 @@
       {
         "allValue": "all",
         "current": {
-          "isNone": true,
           "selected": false,
-          "text": "None",
-          "value": ""
+          "text": "ip-10-203-100-74.eu-west-1.compute.internal",
+          "value": "ip-10-203-100-74.eu-west-1.compute.internal"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
         },
         "definition": "label_values(kube_pod_info{created_by_name!=\"<none>\", namespace=\"$namespace\", pod=\"$pod\"}, node)",
         "hide": 0,
@@ -1637,10 +1851,13 @@
       },
       {
         "current": {
-          "isNone": true,
           "selected": false,
-          "text": "None",
-          "value": ""
+          "text": "m4.xlarge",
+          "value": "m4.xlarge"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
         },
         "definition": "label_values(kube_node_labels, label_beta_kubernetes_io_instance_type) ",
         "hide": 0,

--- a/docs/transformation.excalidraw
+++ b/docs/transformation.excalidraw
@@ -154,14 +154,14 @@
         }
       ],
       "updated": 1642667519760,
-      "text": "instance_mem_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1a\",region=\"eu-west-1\",unit=\"Hrs\"} 0.0019893973214285716\ninstance_mem_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1b\",region=\"eu-west-1\",unit=\"Hrs\"} 0.0023477678571428573\ninstance_mem_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1c\",region=\"eu-west-1\",unit=\"Hrs\"} 0.0017373511904761904",
+      "text": "instance_mem_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1a\",region=\"eu-west-1\",unit=\"Hrs\"} 0.0019893973214285716\ninstance_mem_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1b\",region=\"eu-west-1\",unit=\"Hrs\"} 0.0023477678571428573\ninstance_mem_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1c\",region=\"eu-west-1\",unit=\"Hrs\"} 0.0017373511904761904",
       "fontSize": 20,
       "fontFamily": 3,
       "textAlign": "left",
       "verticalAlign": "top",
       "baseline": 67,
       "containerId": null,
-      "originalText": "instance_mem_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1a\",region=\"eu-west-1\",unit=\"Hrs\"} 0.0019893973214285716\ninstance_mem_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1b\",region=\"eu-west-1\",unit=\"Hrs\"} 0.0023477678571428573\ninstance_mem_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1c\",region=\"eu-west-1\",unit=\"Hrs\"} 0.0017373511904761904"
+      "originalText": "instance_mem_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1a\",region=\"eu-west-1\",unit=\"Hrs\"} 0.0019893973214285716\ninstance_mem_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1b\",region=\"eu-west-1\",unit=\"Hrs\"} 0.0023477678571428573\ninstance_mem_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1c\",region=\"eu-west-1\",unit=\"Hrs\"} 0.0017373511904761904"
     },
     {
       "id": "yGyZsE3-jVvo98yBwyXeD",
@@ -191,14 +191,14 @@
         }
       ],
       "updated": 1642667524267,
-      "text": "instance_cpu_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1a\",region=\"eu-west-1\",unit=\"Hrs\"} 0.014323660714285716\ninstance_cpu_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1b\",region=\"eu-west-1\",unit=\"Hrs\"} 0.016903928571428573\ninstance_cpu_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1c\",region=\"eu-west-1\",unit=\"Hrs\"} 0.012508928571428572",
+      "text": "instance_cpu_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1a\",region=\"eu-west-1\",unit=\"Hrs\"} 0.014323660714285716\ninstance_cpu_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1b\",region=\"eu-west-1\",unit=\"Hrs\"} 0.016903928571428573\ninstance_cpu_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1c\",region=\"eu-west-1\",unit=\"Hrs\"} 0.012508928571428572",
       "fontSize": 20,
       "fontFamily": 3,
       "textAlign": "left",
       "verticalAlign": "top",
       "baseline": 67,
       "containerId": null,
-      "originalText": "instance_cpu_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1a\",region=\"eu-west-1\",unit=\"Hrs\"} 0.014323660714285716\ninstance_cpu_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1b\",region=\"eu-west-1\",unit=\"Hrs\"} 0.016903928571428573\ninstance_cpu_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1c\",region=\"eu-west-1\",unit=\"Hrs\"} 0.012508928571428572"
+      "originalText": "instance_cpu_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1a\",region=\"eu-west-1\",unit=\"Hrs\"} 0.014323660714285716\ninstance_cpu_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1b\",region=\"eu-west-1\",unit=\"Hrs\"} 0.016903928571428573\ninstance_cpu_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1c\",region=\"eu-west-1\",unit=\"Hrs\"} 0.012508928571428572"
     },
     {
       "id": "zA3gYJnDKCQWEDGVY7OfX",
@@ -228,14 +228,14 @@
         }
       ],
       "updated": 1642667528891,
-      "text": "instance_cost{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1a\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.089125\ninstance_cost{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1b\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.10518000000000001\ninstance_cost{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1c\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.07783333333333332",
+      "text": "instance_cost{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1a\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.089125\ninstance_cost{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1b\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.10518000000000001\ninstance_cost{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1c\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.07783333333333332",
       "fontSize": 20,
       "fontFamily": 3,
       "textAlign": "left",
       "verticalAlign": "top",
       "baseline": 67,
       "containerId": null,
-      "originalText": "instance_cost{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1a\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.089125\ninstance_cost{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1b\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.10518000000000001\ninstance_cost{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1c\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.07783333333333332"
+      "originalText": "instance_cost{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1a\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.089125\ninstance_cost{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1b\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.10518000000000001\ninstance_cost{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"SPOT\",label_topology_kubernetes_io_zone=\"eu-west-1c\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.07783333333333332"
     },
     {
       "id": "FyDKRH4Q32xi7Uq_jMBAQ",
@@ -265,14 +265,14 @@
         }
       ],
       "updated": 1642667526359,
-      "text": "instance_cost{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\",label_topology_kubernetes_io_zone=\"\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.214",
+      "text": "instance_cost{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\",label_topology_kubernetes_io_zone=\"\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.214",
       "fontSize": 20,
       "fontFamily": 3,
       "textAlign": "left",
       "verticalAlign": "top",
       "baseline": 19,
       "containerId": null,
-      "originalText": "instance_cost{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\",label_topology_kubernetes_io_zone=\"\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.214"
+      "originalText": "instance_cost{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\",label_topology_kubernetes_io_zone=\"\",memory=\"16 GiB\",region=\"eu-west-1\",unit=\"Hrs\",vcpu=\"4\"} 0.214"
     },
     {
       "id": "l_7B4zABkYsYpSAKOZjQE",
@@ -302,14 +302,14 @@
         }
       ],
       "updated": 1642667522029,
-      "text": "instance_cpu_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\",label_topology_kubernetes_io_zone=\"\",region=\"eu-west-1\",unit=\"Hrs\"} 0.03439285714285714",
+      "text": "instance_cpu_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\",label_topology_kubernetes_io_zone=\"\",region=\"eu-west-1\",unit=\"Hrs\"} 0.03439285714285714",
       "fontSize": 20,
       "fontFamily": 3,
       "textAlign": "left",
       "verticalAlign": "top",
       "baseline": 19,
       "containerId": null,
-      "originalText": "instance_cpu_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\",label_topology_kubernetes_io_zone=\"\",region=\"eu-west-1\",unit=\"Hrs\"} 0.03439285714285714"
+      "originalText": "instance_cpu_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\",label_topology_kubernetes_io_zone=\"\",region=\"eu-west-1\",unit=\"Hrs\"} 0.03439285714285714"
     },
     {
       "id": "XNyab4hZmXNep4ZL8zCcS",
@@ -334,14 +334,14 @@
       "isDeleted": false,
       "boundElements": null,
       "updated": 1642667494985,
-      "text": "instance_mem_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\",label_topology_kubernetes_io_zone=\"\",region=\"eu-west-1\",unit=\"Hrs\"} 0.004776785714285714",
+      "text": "instance_mem_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\",label_topology_kubernetes_io_zone=\"\",region=\"eu-west-1\",unit=\"Hrs\"} 0.004776785714285714",
       "fontSize": 20,
       "fontFamily": 3,
       "textAlign": "left",
       "verticalAlign": "top",
       "baseline": 19,
       "containerId": null,
-      "originalText": "instance_mem_price{label_beta_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\",label_topology_kubernetes_io_zone=\"\",region=\"eu-west-1\",unit=\"Hrs\"} 0.004776785714285714"
+      "originalText": "instance_mem_price{label_node_kubernetes_io_instance_type=\"m6i.xlarge\",label_eks_amazonaws_com_capacity_type=\"ON_DEMAND\",label_topology_kubernetes_io_zone=\"\",region=\"eu-west-1\",unit=\"Hrs\"} 0.004776785714285714"
     },
     {
       "id": "X5EEdO3lxyk4ladCNZRQ1",


### PR DESCRIPTION
#34 
After research been done about label replacement in Prometheus, the easiest approach to avoid data loss and stop scraping deprecated labels from K8s is duplicating queries in the dashboards and only get the new label from clusters.